### PR TITLE
feat: add total-functions rule

### DIFF
--- a/app/example/unsafe-assertion.ts
+++ b/app/example/unsafe-assertion.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const value: any = "hello";
+
+// ❌ unsafe type assertion
+const length = (value as number).toFixed(2);
+
+console.info(length);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactNative from 'eslint-plugin-react-native';
 import sonarjs from 'eslint-plugin-sonarjs';
 import tseslint from 'typescript-eslint';
+import totalFunctions from 'eslint-plugin-total-functions';
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /** @type {import('eslint').ESLint.Plugin} */
@@ -36,6 +37,7 @@ export default [
     plugins: {
       'react-native': reactNativePlugin,
       import: importPlugin,
+      'total-functions': totalFunctions,
     },
     settings: {
       react: {
@@ -124,8 +126,8 @@ export default [
 
       /* -------------------------------------------------------
         'total-functions/no-unsafe-type-assertion': 'error'
-        が最新のESlintに対応してないため以下にて代替
       ---------------------------------------------------------- */
+      'total-functions/no-unsafe-type-assertion': 'error',
       /* <Type> スタイルは警告、object literal の場合は許容 */
       '@typescript-eslint/consistent-type-assertions': [
         'warn',

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.38.0",
     "husky": "^9.1.3",
-    "lint-staged": "^15.2.8"
+    "lint-staged": "^15.2.8",
+    "eslint-plugin-total-functions": "latest"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": "eslint --max-warnings=0"


### PR DESCRIPTION
## Summary
- add total-functions ESLint plugin and enable no-unsafe-type-assertion rule
- provide sample TypeScript file demonstrating unsafe assertion

## Testing
- `npx eslint app/example/unsafe-assertion.ts` *(fails: Cannot find package 'eslint-plugin-total-functions')*

------
https://chatgpt.com/codex/tasks/task_e_68baed6e7e8c83249e761b282e004bbe