### PR TITLE
Add options prop to CountryPickerField

### DIFF
--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -2,30 +2,19 @@ import { type FC, useCallback, useMemo, useRef, useState } from 'react';
 import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
-import type { TypeFormValues } from './_type';
+import type { TypeCountryPickerField, TypeFormValues } from './_type';
 import type { ComponentProps } from 'react';
 import type { FieldError, Merge } from 'react-hook-form';
 
 /* -----------------------------------------------
  * セレクトボックス
  * ----------------------------------------------- */
-type CountryOption = {
-  label: string;
-  value: string;
-};
-
-const DEFAULT_COUNTRY_OPTIONS: CountryOption[] = [
-  { label: 'セレクトラベル-A', value: 'SelectValue-A' },
-  { label: 'セレクトラベル-B', value: 'SelectValue-B' },
-  { label: 'セレクトラベル-C', value: 'SelectValue-C' },
-];
-
-export const CountryPickerField: FC<{
-  hasError: boolean;
-  onChange: (value: string) => void;
-  value: string;
-  options?: CountryOption[];
-}> = ({ hasError, onChange, value, options = DEFAULT_COUNTRY_OPTIONS }) => {
+export const CountryPickerField: FC<TypeCountryPickerField> = ({
+  hasError,
+  onChange,
+  value,
+  options,
+}) => {
   const pickerRef = useRef<RNPickerSelect | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 

--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -9,10 +9,12 @@ import type { FieldError, Merge } from 'react-hook-form';
 /* -----------------------------------------------
  * セレクトボックス
  * ----------------------------------------------- */
-const COUNTRY_OPTIONS: {
+type CountryOption = {
   label: string;
   value: string;
-}[] = [
+};
+
+const DEFAULT_COUNTRY_OPTIONS: CountryOption[] = [
   { label: 'セレクトラベル-A', value: 'SelectValue-A' },
   { label: 'セレクトラベル-B', value: 'SelectValue-B' },
   { label: 'セレクトラベル-C', value: 'SelectValue-C' },
@@ -22,13 +24,14 @@ export const CountryPickerField: FC<{
   hasError: boolean;
   onChange: (value: string) => void;
   value: string;
-}> = ({ hasError, onChange, value }) => {
+  options?: CountryOption[];
+}> = ({ hasError, onChange, value, options = DEFAULT_COUNTRY_OPTIONS }) => {
   const pickerRef = useRef<RNPickerSelect | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const selectedLabel = useMemo(
-    () => COUNTRY_OPTIONS.find((option) => option.value === value)?.label,
-    [value],
+    () => options.find((option) => option.value === value)?.label,
+    [options, value],
   );
 
   const handleOpenPicker = useCallback(() => {
@@ -68,7 +71,7 @@ export const CountryPickerField: FC<{
           pickerRef.current = ref;
         }}
         doneText='完了'
-        items={COUNTRY_OPTIONS}
+        items={options}
         onClose={() => {
           setIsPickerOpen(false);
         }}

--- a/app/features/main/home/homeNest/child00/_screen.tsx
+++ b/app/features/main/home/homeNest/child00/_screen.tsx
@@ -188,14 +188,14 @@ const Child00Screen: FC = () => {
           rules={{ required: 'セレクトボックス は必須です。' }}
           render={({ field: { onChange, value } }) => (
             <CountryPickerField
-              hasError={errors.country != null}
-              onChange={onChange}
-              value={value}
               options={[
                 { label: 'セレクトラベル-A', value: 'SelectValue-A' },
                 { label: 'セレクトラベル-B', value: 'SelectValue-B' },
                 { label: 'セレクトラベル-C', value: 'SelectValue-C' },
               ]}
+              hasError={errors.country != null}
+              onChange={onChange}
+              value={value}
             />
           )}
         />

--- a/app/features/main/home/homeNest/child00/_screen.tsx
+++ b/app/features/main/home/homeNest/child00/_screen.tsx
@@ -191,6 +191,11 @@ const Child00Screen: FC = () => {
               hasError={errors.country != null}
               onChange={onChange}
               value={value}
+              options={[
+                { label: 'セレクトラベル-A', value: 'SelectValue-A' },
+                { label: 'セレクトラベル-B', value: 'SelectValue-B' },
+                { label: 'セレクトラベル-C', value: 'SelectValue-C' },
+              ]}
             />
           )}
         />

--- a/app/features/main/home/homeNest/child00/_type.ts
+++ b/app/features/main/home/homeNest/child00/_type.ts
@@ -6,3 +6,13 @@ export type TypeFormValues = {
   country: string;
   note: string;
 };
+
+export type TypeCountryPickerField = {
+  options: {
+    label: string;
+    value: string;
+  }[];
+  hasError: boolean;
+  onChange: (value: string) => void;
+  value: string;
+};


### PR DESCRIPTION
## Summary
- allow the CountryPickerField component to accept custom option lists
- update the child00 screen to provide explicit country options

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907c930e274832488ea6d798c64c2b5