### PR TITLE
Replace Child00 select with native picker

### DIFF
--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -1,9 +1,8 @@
-import { type FC, useCallback, useMemo, useRef, useState } from 'react';
-import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
-import RNPickerSelect from 'react-native-picker-select';
+import { Picker } from '@react-native-picker/picker';
+import { type FC, useCallback } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 
 import type { TypeCountryPickerField, TypeFormValues } from './_type';
-import type { ComponentProps } from 'react';
 import type { FieldError, Merge } from 'react-hook-form';
 
 /* -----------------------------------------------
@@ -15,20 +14,6 @@ export const CountryPickerField: FC<TypeCountryPickerField> = ({
   value,
   options,
 }) => {
-  const pickerRef = useRef<RNPickerSelect | null>(null);
-  const [isPickerOpen, setIsPickerOpen] = useState(false);
-
-  const selectedLabel = useMemo(
-    () => options.find((option) => option.value === value)?.label,
-    [options, value],
-  );
-
-  const handleOpenPicker = useCallback(() => {
-    Keyboard.dismiss();
-    setIsPickerOpen(true);
-    pickerRef.current?.togglePicker(true);
-  }, []);
-
   const handleValueChange = useCallback(
     (selectedValue: string | null) => {
       onChange(selectedValue ?? '');
@@ -37,42 +22,19 @@ export const CountryPickerField: FC<TypeCountryPickerField> = ({
   );
 
   return (
-    <View>
-      <Pressable
-        accessibilityRole='button'
-        accessibilityState={{ expanded: isPickerOpen }}
-        onPress={handleOpenPicker}
-        style={[selectStyles.selectTrigger, hasError ? selectStyles.inputError : null]}
-      >
-        <Text
-          style={
-            selectedLabel == null
-              ? selectStyles.selectPlaceholderText
-              : selectStyles.selectValueText
-          }
-        >
-          {selectedLabel ?? '選択してください'}
-        </Text>
-      </Pressable>
-
-      <RNPickerSelect
-        ref={(ref) => {
-          pickerRef.current = ref;
-        }}
-        doneText='完了'
-        items={options}
-        onClose={() => {
-          setIsPickerOpen(false);
-        }}
-        onOpen={() => {
-          setIsPickerOpen(true);
-        }}
+    <View style={[selectStyles.selectWrapper, hasError ? selectStyles.inputError : null]}>
+      <Picker
+        dropdownIconColor='#616161'
+        mode={Platform.OS === 'android' ? 'dropdown' : undefined}
         onValueChange={handleValueChange}
-        placeholder={{ label: '選択してください', value: '' }}
-        style={pickerSelectStyles}
-        useNativeAndroidPickerStyle={false}
-        value={value === '' ? null : value}
-      />
+        selectedValue={value}
+        style={selectStyles.picker}
+      >
+        <Picker.Item label='選択してください' value='' color='#9e9e9e' />
+        {options.map((option) => (
+          <Picker.Item key={option.value} label={option.label} value={option.value} color='#212121' />
+        ))}
+      </Picker>
     </View>
   );
 };
@@ -80,7 +42,7 @@ const selectStyles = StyleSheet.create({
   inputError: {
     borderColor: '#e53935',
   },
-  selectTrigger: {
+  selectWrapper: {
     alignItems: 'center',
     backgroundColor: '#fff',
     borderColor: '#d6d6d6',
@@ -88,59 +50,15 @@ const selectStyles = StyleSheet.create({
     borderWidth: 1,
     flexDirection: 'row',
     minHeight: 44,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
+    overflow: 'hidden',
   },
-  selectValueText: {
+  picker: {
     color: '#212121',
+    flex: 1,
     fontSize: 14,
-  },
-  selectPlaceholderText: {
-    color: '#9e9e9e',
-    fontSize: 14,
+    height: Platform.OS === 'web' ? '100%' : 44,
   },
 });
-
-type PickerSelectStyles = NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
-const pickerSelectStyles: PickerSelectStyles = {
-  inputIOS: {
-    height: 0,
-    opacity: 0,
-    padding: 0,
-  },
-  inputAndroid: {
-    height: 0,
-    opacity: 0,
-    padding: 0,
-  },
-  inputWeb: {
-    height: '100%',
-    width: '100%',
-    borderRadius: 8,
-    opacity: 0,
-  },
-  placeholder: {
-    color: '#9e9e9e',
-  },
-  viewContainer: {
-    height: '100%',
-    width: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-  },
-  modalViewMiddle: {
-    backgroundColor: '#fff',
-  },
-  modalViewBottom: {
-    backgroundColor: '#fff',
-  },
-  done: {
-    color: '#007aff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-};
 
 /* -----------------------------------------------
  * エラーテキスト

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react": "19.1.0",
     "react-hook-form": "^7.66.0",
     "react-native": "0.81.4",
-    "react-native-picker-select": "^9.3.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-pager-view": "6.9.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4903,16 +4903,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
-
 lodash.merge@4.6.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -6092,14 +6082,6 @@ react-native-pager-view@6.9.1:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.9.1.tgz#a9e6d9323935cc2ae1d46d7816b66f76dc3eff8e"
   integrity sha512-uUT0MMMbNtoSbxe9pRvdJJKEi9snjuJ3fXlZhG8F2vVMOBJVt/AFtqMPUHu9yMflmqOr08PewKzj9EPl/Yj+Gw==
-
-react-native-picker-select@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-picker-select/-/react-native-picker-select-9.3.1.tgz#8a2ad51c286fcd54ef60fb883842ec1895c15003"
-  integrity sha512-o621HcsKJfJkpYeP/PZQiZTKbf8W7FT08niLFL0v1pGkIQyak5IfzfinV2t+/l1vktGwAH2Tt29LrP/Hc5fk3A==
-  dependencies:
-    lodash.isequal "^4.5.0"
-    lodash.isobject "^3.0.2"
 
 react-native-safe-area-context@~5.6.0:
   version "5.6.1"


### PR DESCRIPTION
## Summary
- refactor the Child00 country picker to use `@react-native-picker/picker` directly and simplify the surrounding styles
- remove the unused `react-native-picker-select` dependency and clean its lockfile entries

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6908dca09b90832491b26bfd43d9093d