### PR TITLE
Create reusable input component for Child00 form fields

### DIFF
--- a/app/components/form/_errorText.tsx
+++ b/app/components/form/_errorText.tsx
@@ -1,0 +1,19 @@
+import { StyleSheet, Text } from 'react-native';
+
+import type { TypeErrorText } from '../../lib/types/typeComponents';
+
+const ErrorText: React.FC<TypeErrorText> = (errorsType) => {
+  if (errorsType.message == null) {
+    return;
+  }
+  return <Text style={errorStyles.text}>{errorsType.message}</Text>;
+};
+const errorStyles = StyleSheet.create({
+  text: {
+    color: '#e53935',
+    fontSize: 12,
+    marginTop: 4,
+  },
+});
+
+export default ErrorText;

--- a/app/components/form/_input.tsx
+++ b/app/components/form/_input.tsx
@@ -1,0 +1,66 @@
+import { type FieldValues, useController } from 'react-hook-form';
+import { StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { ErrorText } from '.';
+
+import type { TypeInputProps } from '../../lib/types/typeComponents';
+
+/* -----------------------------------------------
+ * テキストインプット
+ * ----------------------------------------------- */
+
+const Input = <TFieldValues extends FieldValues>({
+  containerStyle,
+  control,
+  errorText,
+  label,
+  name,
+  rules,
+  style,
+  ...textInputProps
+}: TypeInputProps<TFieldValues>) => {
+  const {
+    field: { onBlur, onChange, value },
+  } = useController({ control, name, rules });
+
+  const inputValue = typeof value === 'string' ? value : '';
+  const hasError = errorText?.message != null;
+
+  return (
+    <View style={[inputStyles.container, containerStyle]}>
+      <Text style={inputStyles.label}>{label}</Text>
+      <TextInput
+        {...textInputProps}
+        onBlur={onBlur}
+        onChangeText={onChange}
+        style={[inputStyles.input, hasError ? inputStyles.inputError : null, style]}
+        value={inputValue}
+      />
+      <ErrorText {...errorText} />
+    </View>
+  );
+};
+
+const inputStyles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderColor: '#d6d6d6',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  inputError: {
+    borderColor: '#e53935',
+  },
+});
+
+export default Input;

--- a/app/components/form/index.ts
+++ b/app/components/form/index.ts
@@ -1,0 +1,2 @@
+export { default as Input } from './_input';
+export { default as ErrorText } from './_errorText';

--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -1,13 +1,72 @@
 import { type FC, useCallback, useMemo, useRef, useState } from 'react';
-import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
+import { type FieldValues, useController } from 'react-hook-form';
+import { Keyboard, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
 import type {
   TypeErrorText,
+  TypeInputProps,
   TypePickerField,
   TypePickerSelectStyles,
   TypeResultArea,
 } from './_type';
+
+/* -----------------------------------------------
+ * テキストインプット
+ * ----------------------------------------------- */
+export const Input = <TFieldValues extends FieldValues>({
+  containerStyle,
+  control,
+  errorText,
+  label,
+  name,
+  rules,
+  style,
+  ...textInputProps
+}: TypeInputProps<TFieldValues>) => {
+  const {
+    field: { onBlur, onChange, value },
+  } = useController({ control, name, rules });
+
+  const inputValue = typeof value === 'string' ? value : '';
+  const hasError = errorText?.message != null;
+
+  return (
+    <View style={[inputStyles.container, containerStyle]}> 
+      <Text style={inputStyles.label}>{label}</Text>
+      <TextInput
+        {...textInputProps}
+        onBlur={onBlur}
+        onChangeText={onChange}
+        style={[inputStyles.input, hasError ? inputStyles.inputError : null, style]}
+        value={inputValue}
+      />
+      <ErrorText {...errorText} />
+    </View>
+  );
+};
+
+const inputStyles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderColor: '#d6d6d6',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  inputError: {
+    borderColor: '#e53935',
+  },
+});
 
 /* -----------------------------------------------
  * セレクトボックス

--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -1,72 +1,8 @@
 import { type FC, useCallback, useMemo, useRef, useState } from 'react';
-import { type FieldValues, useController } from 'react-hook-form';
-import { Keyboard, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
-import type {
-  TypeErrorText,
-  TypeInputProps,
-  TypePickerField,
-  TypePickerSelectStyles,
-  TypeResultArea,
-} from './_type';
-
-/* -----------------------------------------------
- * テキストインプット
- * ----------------------------------------------- */
-export const Input = <TFieldValues extends FieldValues>({
-  containerStyle,
-  control,
-  errorText,
-  label,
-  name,
-  rules,
-  style,
-  ...textInputProps
-}: TypeInputProps<TFieldValues>) => {
-  const {
-    field: { onBlur, onChange, value },
-  } = useController({ control, name, rules });
-
-  const inputValue = typeof value === 'string' ? value : '';
-  const hasError = errorText?.message != null;
-
-  return (
-    <View style={[inputStyles.container, containerStyle]}> 
-      <Text style={inputStyles.label}>{label}</Text>
-      <TextInput
-        {...textInputProps}
-        onBlur={onBlur}
-        onChangeText={onChange}
-        style={[inputStyles.input, hasError ? inputStyles.inputError : null, style]}
-        value={inputValue}
-      />
-      <ErrorText {...errorText} />
-    </View>
-  );
-};
-
-const inputStyles = StyleSheet.create({
-  container: {
-    marginBottom: 16,
-  },
-  label: {
-    fontSize: 14,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  input: {
-    backgroundColor: '#fff',
-    borderColor: '#d6d6d6',
-    borderRadius: 8,
-    borderWidth: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-  },
-  inputError: {
-    borderColor: '#e53935',
-  },
-});
+import type { TypePickerField, TypePickerSelectStyles, TypeResultArea } from './_type';
 
 /* -----------------------------------------------
  * セレクトボックス
@@ -197,23 +133,6 @@ const pickerSelectStyles: TypePickerSelectStyles = {
     fontWeight: '600',
   },
 };
-
-/* -----------------------------------------------
- * エラーテキスト
- * ----------------------------------------------- */
-export const ErrorText: React.FC<TypeErrorText> = (errorsType) => {
-  if (errorsType.message == null) {
-    return;
-  }
-  return <Text style={errorStyles.text}>{errorsType.message}</Text>;
-};
-const errorStyles = StyleSheet.create({
-  text: {
-    color: '#e53935',
-    fontSize: 12,
-    marginTop: 4,
-  },
-});
 
 /* -----------------------------------------------
  * submit 出力結果表示エリア

--- a/app/features/main/home/homeNest/child00/_screen.tsx
+++ b/app/features/main/home/homeNest/child00/_screen.tsx
@@ -1,8 +1,8 @@
 import { type FC, useCallback, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Button, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Button, Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { ErrorText, PickerField, ResultArea } from './_component';
+import { ErrorText, Input, PickerField, ResultArea } from './_component';
 import { Layout } from '../../../../../components/layout';
 
 import type { TypeFormValues } from './_type';
@@ -48,53 +48,33 @@ const Child00Screen: FC = () => {
       <Text style={styles.title}>react-hook-form example</Text>
 
       {/* Name インプット項目 */}
-      <View style={styles.fieldGroup}>
-        <Text style={styles.label}>Name</Text>
-        <Controller
-          control={control}
-          name='name'
-          rules={{ required: 'Name は必須です。' }}
-          render={({ field: { onBlur, onChange, value } }) => (
-            <TextInput
-              autoCapitalize='words'
-              onBlur={onBlur}
-              onChangeText={onChange}
-              placeholder='Jane Doe'
-              style={[styles.input, errors.name ? styles.inputError : null]}
-              value={value}
-            />
-          )}
-        />
-        <ErrorText {...errors.name} />
-      </View>
+      <Input
+        autoCapitalize='words'
+        control={control}
+        errorText={errors.name}
+        label='Name'
+        name='name'
+        placeholder='Jane Doe'
+        rules={{ required: 'Name は必須です。' }}
+      />
 
       {/* Email インプット項目 */}
-      <View style={styles.fieldGroup}>
-        <Text style={styles.label}>Email</Text>
-        <Controller
-          control={control}
-          name='email'
-          rules={{
-            pattern: {
-              message: 'Emailアドレスを入力してください.',
-              value: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/,
-            },
-            required: 'Email は必須です。',
-          }}
-          render={({ field: { onBlur, onChange, value } }) => (
-            <TextInput
-              autoCapitalize='none'
-              keyboardType='ascii-capable'
-              onBlur={onBlur}
-              onChangeText={onChange}
-              placeholder='jane@example.com'
-              style={[styles.input, errors.email ? styles.inputError : null]}
-              value={value}
-            />
-          )}
-        />
-        <ErrorText {...errors.email} />
-      </View>
+      <Input
+        autoCapitalize='none'
+        control={control}
+        errorText={errors.email}
+        keyboardType='ascii-capable'
+        label='Email'
+        name='email'
+        placeholder='jane@example.com'
+        rules={{
+          pattern: {
+            message: 'Emailアドレスを入力してください.',
+            value: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/,
+          },
+          required: 'Email は必須です。',
+        }}
+      />
 
       {/* Subscribe チェックボックス */}
       <View style={styles.fieldGroup}>
@@ -198,33 +178,24 @@ const Child00Screen: FC = () => {
       </View>
 
       {/* Note テキストエリア */}
-      <View style={styles.fieldGroup}>
-        <Text style={styles.label}>Note</Text>
-        <Controller
-          control={control}
-          name='note'
-          rules={{
-            maxLength: {
-              value: 200,
-              message: '200文字以内で入力してください。',
-            },
-            required: 'テキストエリア は必須です。',
-          }}
-          render={({ field: { onBlur, onChange, value } }) => (
-            <TextInput
-              multiline
-              numberOfLines={4}
-              onBlur={onBlur}
-              onChangeText={onChange}
-              placeholder='メモや補足を入力してください'
-              style={[styles.input, styles.textArea, errors.note ? styles.inputError : null]}
-              textAlignVertical='top'
-              value={value}
-            />
-          )}
-        />
-        <ErrorText {...errors.note} />
-      </View>
+      <Input
+        control={control}
+        errorText={errors.note}
+        label='Note'
+        multiline
+        name='note'
+        numberOfLines={4}
+        placeholder='メモや補足を入力してください'
+        rules={{
+          maxLength: {
+            value: 200,
+            message: '200文字以内で入力してください。',
+          },
+          required: 'テキストエリア は必須です。',
+        }}
+        style={styles.textArea}
+        textAlignVertical='top'
+      />
 
       {/* submit ボタン */}
       <View style={styles.actions}>
@@ -252,17 +223,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
     marginBottom: 8,
-  },
-  input: {
-    backgroundColor: '#fff',
-    borderColor: '#d6d6d6',
-    borderRadius: 8,
-    borderWidth: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-  },
-  inputError: {
-    borderColor: '#e53935',
   },
   checkboxGroup: {
     rowGap: 12,

--- a/app/features/main/home/homeNest/child00/_screen.tsx
+++ b/app/features/main/home/homeNest/child00/_screen.tsx
@@ -1,13 +1,14 @@
-import { type FC, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Button, Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { ErrorText, Input, PickerField, ResultArea } from './_component';
+import { PickerField, ResultArea } from './_component';
+import { ErrorText, Input } from '../../../../../components/form';
 import { Layout } from '../../../../../components/layout';
 
 import type { TypeFormValues } from './_type';
 
-const Child00Screen: FC = () => {
+const Child00Screen: React.FC = () => {
   const [submittedValues, setSubmittedValues] = useState<TypeFormValues | null>(null);
 
   // form設定

--- a/app/features/main/home/homeNest/child00/_type.ts
+++ b/app/features/main/home/homeNest/child00/_type.ts
@@ -1,6 +1,14 @@
 import type { ComponentProps } from 'react';
-import type { FieldError, Merge } from 'react-hook-form';
+import type {
+  Control,
+  FieldError,
+  FieldValues,
+  Merge,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
 import type RNPickerSelect from 'react-native-picker-select';
+import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * ./_screen.tsx
@@ -32,3 +40,13 @@ export type TypePickerSelectStyles = NonNullable<ComponentProps<typeof RNPickerS
 export type TypeErrorText = Merge<FieldError, (FieldError | undefined)[]>;
 
 export type TypeResultArea = Partial<TypeFormValues>;
+
+export type TypeInputProps<TFieldValues extends FieldValues> = {
+  label: string;
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
+  errorText?: TypeErrorText | FieldError;
+  containerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
+} & Omit<TextInputProps, 'onBlur' | 'onChangeText' | 'value' | 'style'>;

--- a/app/features/main/home/homeNest/child00/_type.ts
+++ b/app/features/main/home/homeNest/child00/_type.ts
@@ -1,14 +1,5 @@
 import type { ComponentProps } from 'react';
-import type {
-  Control,
-  FieldError,
-  FieldValues,
-  Merge,
-  Path,
-  RegisterOptions,
-} from 'react-hook-form';
 import type RNPickerSelect from 'react-native-picker-select';
-import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * ./_screen.tsx
@@ -37,16 +28,4 @@ export type TypePickerField = {
 
 export type TypePickerSelectStyles = NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
 
-export type TypeErrorText = Merge<FieldError, (FieldError | undefined)[]>;
-
 export type TypeResultArea = Partial<TypeFormValues>;
-
-export type TypeInputProps<TFieldValues extends FieldValues> = {
-  label: string;
-  control: Control<TFieldValues>;
-  name: Path<TFieldValues>;
-  rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
-  errorText?: TypeErrorText | FieldError;
-  containerStyle?: StyleProp<ViewStyle>;
-  style?: StyleProp<TextStyle>;
-} & Omit<TextInputProps, 'onBlur' | 'onChangeText' | 'value' | 'style'>;

--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -1,0 +1,27 @@
+import type {
+  Control,
+  FieldError,
+  FieldValues,
+  Merge,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
+import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
+
+/* -----------------------------------------------
+ * type エラーテキスト
+ * ----------------------------------------------- */
+export type TypeErrorText = Merge<FieldError, (FieldError | undefined)[]>;
+
+/* -----------------------------------------------
+ * type インプット
+ * ----------------------------------------------- */
+export type TypeInputProps<TFieldValues extends FieldValues> = {
+  label: string;
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
+  errorText?: TypeErrorText | FieldError;
+  containerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
+} & Omit<TextInputProps, 'onBlur' | 'onChangeText' | 'value' | 'style'>;

--- a/app/lib/types/typeComponents/index.ts
+++ b/app/lib/types/typeComponents/index.ts
@@ -1,2 +1,3 @@
+export * from './_form';
 export * from './_layout';
 export * from './_svg';


### PR DESCRIPTION
## Summary
- add a reusable `Input` component that wraps react-hook-form controllers for text inputs
- replace inline name, email, and note fields in the Child00 screen with the new component for consistency
- extend shared types to describe the new input component props

## Testing
- yarn lint *(fails: workspace package missing from lockfile in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e122e4ae88324b516970a69fa703e)