### PR TITLE
Integrate custom check and radio boxes into Child00 screen

### DIFF
--- a/app/components/form/_customCheckBox.tsx
+++ b/app/components/form/_customCheckBox.tsx
@@ -1,0 +1,166 @@
+import { type FieldValues, useController } from 'react-hook-form';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import ErrorText from './_errorText';
+
+import type { TypeCustomCheckBox } from '../../lib/types/typeComponents';
+
+/* -----------------------------------------------
+ * カスタムデザイン チェックボックス
+ * ----------------------------------------------- */
+
+const CustomCheckBox = <TFieldValues extends FieldValues>({
+  containerStyle,
+  control,
+  errorText,
+  label,
+  labelStyle,
+  name,
+  optionListStyle,
+  optionRowStyle,
+  options,
+  required,
+  rules,
+}: TypeCustomCheckBox<TFieldValues>) => {
+  const {
+    field: { value, onChange },
+  } = useController({ control, name, rules });
+
+  const selectedValues = Array.isArray(value) ? (value as string[]) : [];
+  const hasError = errorText?.message != null;
+
+  const handleToggle = (optionValue: string) => {
+    if (selectedValues.includes(optionValue)) {
+      onChange(selectedValues.filter((selected) => selected !== optionValue));
+      return;
+    }
+    onChange([...selectedValues, optionValue]);
+  };
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <View style={styles.labelRow}>
+        <Text style={[styles.label, labelStyle]}>{label}</Text>
+        {required ? <Text style={styles.required}>*</Text> : null}
+      </View>
+      <View style={[styles.optionList, optionListStyle]}>
+        {options.map((option) => {
+          const isSelected = selectedValues.includes(option.value);
+          const isDisabled = option.disabled ?? false;
+          return (
+            <Pressable
+              key={option.key ?? option.value}
+              accessibilityRole='checkbox'
+              accessibilityState={{ checked: isSelected, disabled: isDisabled }}
+              disabled={isDisabled}
+              onPress={() => {
+                handleToggle(option.value);
+              }}
+              style={[
+                styles.optionRow,
+                isSelected ? styles.optionRowSelected : null,
+                hasError ? styles.optionRowError : null,
+                isDisabled ? styles.optionRowDisabled : null,
+                optionRowStyle,
+              ]}
+            >
+              <View
+                style={[
+                  styles.indicator,
+                  isSelected ? styles.indicatorSelected : null,
+                  isDisabled ? styles.indicatorDisabled : null,
+                ]}
+              />
+              <Text
+                style={[
+                  styles.optionLabel,
+                  isSelected ? styles.optionLabelSelected : null,
+                  isDisabled ? styles.optionLabelDisabled : null,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <ErrorText {...errorText} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  labelRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    columnGap: 4,
+    marginBottom: 8,
+  },
+  label: {
+    color: '#1c1c1e',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  required: {
+    color: '#ff3b30',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  optionList: {
+    rowGap: 8,
+  },
+  optionRow: {
+    alignItems: 'center',
+    backgroundColor: '#f2f2f7',
+    borderColor: '#d1d1d6',
+    borderRadius: 20,
+    borderWidth: 1,
+    columnGap: 12,
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  optionRowSelected: {
+    backgroundColor: '#ffffff',
+    borderColor: '#3182f6',
+    shadowColor: '#00000020',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.15,
+    shadowRadius: 3,
+  },
+  optionRowError: {
+    borderColor: '#e53935',
+  },
+  optionRowDisabled: {
+    opacity: 0.6,
+  },
+  indicator: {
+    backgroundColor: '#d1d1d6',
+    borderRadius: 999,
+    height: 18,
+    width: 18,
+  },
+  indicatorSelected: {
+    backgroundColor: '#3182f6',
+  },
+  indicatorDisabled: {
+    backgroundColor: '#e5e5ea',
+  },
+  optionLabel: {
+    color: '#636366',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  optionLabelSelected: {
+    color: '#3182f6',
+    fontWeight: '600',
+  },
+  optionLabelDisabled: {
+    color: '#aeaeb2',
+  },
+});
+
+export default CustomCheckBox;

--- a/app/components/form/_customRadioBox.tsx
+++ b/app/components/form/_customRadioBox.tsx
@@ -1,0 +1,159 @@
+import { type FieldValues, useController } from 'react-hook-form';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import ErrorText from './_errorText';
+
+import type { TypeCustomRadioBox } from '../../lib/types/typeComponents';
+
+/* -----------------------------------------------
+ * カスタムデザイン ラヂオボックス
+ * ----------------------------------------------- */
+
+const CustomRadioBox = <TFieldValues extends FieldValues>({
+  containerStyle,
+  control,
+  errorText,
+  label,
+  labelStyle,
+  name,
+  optionListStyle,
+  optionRowStyle,
+  options,
+  required,
+  rules,
+}: TypeCustomRadioBox<TFieldValues>) => {
+  const {
+    field: { value, onChange },
+  } = useController({ control, name, rules });
+
+  const selectedValue = typeof value === 'string' ? value : '';
+  const hasError = errorText?.message != null;
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <View style={styles.labelRow}>
+        <Text style={[styles.label, labelStyle]}>{label}</Text>
+        {required ? <Text style={styles.required}>*</Text> : null}
+      </View>
+      <View style={[styles.optionList, optionListStyle]}>
+        {options.map((option) => {
+          const isSelected = selectedValue === option.value;
+          const isDisabled = option.disabled ?? false;
+          return (
+            <Pressable
+              key={option.key ?? option.value}
+              accessibilityRole='radio'
+              accessibilityState={{ selected: isSelected, disabled: isDisabled }}
+              disabled={isDisabled}
+              onPress={() => {
+                onChange(option.value);
+              }}
+              style={[
+                styles.optionRow,
+                isSelected ? styles.optionRowSelected : null,
+                hasError ? styles.optionRowError : null,
+                isDisabled ? styles.optionRowDisabled : null,
+                optionRowStyle,
+              ]}
+            >
+              <View style={[styles.indicator, isSelected ? styles.indicatorSelected : null]}>
+                {isSelected ? <View style={styles.indicatorInner} /> : null}
+              </View>
+              <Text
+                style={[
+                  styles.optionLabel,
+                  isSelected ? styles.optionLabelSelected : null,
+                  isDisabled ? styles.optionLabelDisabled : null,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <ErrorText {...errorText} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  labelRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    columnGap: 4,
+    marginBottom: 8,
+  },
+  label: {
+    color: '#1c1c1e',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  required: {
+    color: '#ff3b30',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  optionList: {
+    rowGap: 8,
+  },
+  optionRow: {
+    alignItems: 'center',
+    backgroundColor: '#f2f2f7',
+    borderColor: '#d1d1d6',
+    borderRadius: 20,
+    borderWidth: 1,
+    columnGap: 12,
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  optionRowSelected: {
+    backgroundColor: '#ffffff',
+    borderColor: '#3182f6',
+    shadowColor: '#00000020',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.15,
+    shadowRadius: 3,
+  },
+  optionRowError: {
+    borderColor: '#e53935',
+  },
+  optionRowDisabled: {
+    opacity: 0.6,
+  },
+  indicator: {
+    alignItems: 'center',
+    backgroundColor: '#d1d1d6',
+    borderRadius: 999,
+    height: 18,
+    justifyContent: 'center',
+    width: 18,
+  },
+  indicatorSelected: {
+    backgroundColor: '#3182f6',
+  },
+  indicatorInner: {
+    backgroundColor: '#ffffff',
+    borderRadius: 999,
+    height: 8,
+    width: 8,
+  },
+  optionLabel: {
+    color: '#636366',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  optionLabelSelected: {
+    color: '#3182f6',
+    fontWeight: '600',
+  },
+  optionLabelDisabled: {
+    color: '#aeaeb2',
+  },
+});
+
+export default CustomRadioBox;

--- a/app/components/form/index.ts
+++ b/app/components/form/index.ts
@@ -2,5 +2,7 @@ export { default as Input } from './_input';
 export { default as ErrorText } from './_errorText';
 export { default as CheckBox } from './_checkBox';
 export { default as RadioBox } from './_radioBox';
+export { default as CustomCheckBox } from './_customCheckBox';
+export { default as CustomRadioBox } from './_customRadioBox';
 export { default as SelectBox } from './_selectBox';
 export { default as TextArea } from './_textarea';

--- a/app/features/main/home/homeNest/child00/_screen.tsx
+++ b/app/features/main/home/homeNest/child00/_screen.tsx
@@ -3,7 +3,13 @@ import { useForm } from 'react-hook-form';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
 import { ResultArea } from './_component';
-import { CheckBox, Input, RadioBox, SelectBox, TextArea } from '../../../../../components/form';
+import {
+  CustomCheckBox,
+  CustomRadioBox,
+  Input,
+  SelectBox,
+  TextArea,
+} from '../../../../../components/form';
 import { Layout } from '../../../../../components/layout';
 
 import type { TypeFormValues } from './_type';
@@ -78,34 +84,44 @@ const Child00Screen: React.FC = () => {
         }}
       />
 
-      {/* Subscribe チェックボックス項目 */}
-      <CheckBox
+      {/* Subscribe カスタムチェックボックス項目 */}
+      <CustomCheckBox
         control={control}
         errorText={errors.subscribe}
-        label='Subscribe チェックボックス項目'
+        label='Subscribe カスタムチェックボックス項目'
         name='subscribe'
         options={[
           { label: 'チェックラベル-A', value: 'CheckValue-A' },
           { label: 'チェックラベル-B', value: 'CheckValue-B' },
-          { label: 'チェックラベル-C', value: 'CheckValue-C' },
+          {
+            disabled: true,
+            label: 'チェックラベル-C（disabled）',
+            value: 'CheckValue-C',
+          },
         ]}
+        required
         rules={{
           validate: (value) => value.length >= 2 || '2つ以上選択してください。',
           required: 'チェックボックス は必須です。',
         }}
       />
 
-      {/* Plan ラヂオボタン項目 */}
-      <RadioBox
+      {/* Plan カスタムラヂオボックス項目 */}
+      <CustomRadioBox
         control={control}
         errorText={errors.plan}
-        label='Plan ラヂオボタン項目'
+        label='Plan カスタムラヂオボックス項目'
         name='plan'
         options={[
           { label: 'ラジオラベル-A', value: 'RadioValue-A' },
           { label: 'ラジオラベル-B', value: 'RadioValue-B' },
-          { label: 'ラジオラベル-C', value: 'RadioValue-C' },
+          {
+            disabled: true,
+            label: 'ラジオラベル-C（disabled）',
+            value: 'RadioValue-C',
+          },
         ]}
+        required
         rules={{
           required: 'ラジオボタン は必須です。',
         }}

--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -66,6 +66,35 @@ export type TypeRadioBox<TFieldValues extends FieldValues> = {
 };
 
 /* -----------------------------------------------
+ * type カスタムチェック/ラヂオボックス共通
+ * ----------------------------------------------- */
+export type TypeCustomToggleOption = TypeCheckBoxOption & {
+  disabled?: boolean;
+};
+
+/* -----------------------------------------------
+ * type カスタムチェックボックス項目
+ * ----------------------------------------------- */
+export type TypeCustomCheckBox<TFieldValues extends FieldValues> = Omit<
+  TypeCheckBox<TFieldValues>,
+  'options'
+> & {
+  options: TypeCustomToggleOption[];
+  required?: boolean;
+};
+
+/* -----------------------------------------------
+ * type カスタムラヂオボックス項目
+ * ----------------------------------------------- */
+export type TypeCustomRadioBox<TFieldValues extends FieldValues> = Omit<
+  TypeRadioBox<TFieldValues>,
+  'options'
+> & {
+  options: TypeCustomToggleOption[];
+  required?: boolean;
+};
+
+/* -----------------------------------------------
  * type セレクトボックス項目
  * ----------------------------------------------- */
 export type TypeSelectBoxOption = Omit<Item, 'value'> & {


### PR DESCRIPTION
## Summary
- replace the standard checkbox and radio inputs on the Child00 screen with the new custom-styled versions
- demonstrate disabled option handling and required markers for the custom toggle components

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4b003b18832496275e2babff6068)