### PR TITLE
Add disabled prop handling to form components

### DIFF
--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -5,7 +5,9 @@ import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 import ErrorText from './_errorText';
 
 import type { TypeCheckBoxCustom, TypeToggleCheckOption } from '../../lib/types/typeComponents';
+import type { ReactElement } from 'react';
 import type { FieldValues } from 'react-hook-form';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * チェックボックスカスタム項目
@@ -31,6 +33,8 @@ const ToggleCheckOption = ({
   optionLabelStyle,
   trackStyle,
   knobStyle,
+  disabled,
+  value,
 }: TypeToggleCheckOption) => {
   const animation = useRef(new Animated.Value(isSelected ? 1 : 0)).current;
 
@@ -52,60 +56,79 @@ const ToggleCheckOption = ({
     outputRange: [KNOB_MARGIN, TRACK_WIDTH - KNOB_SIZE - KNOB_MARGIN],
   });
 
-  const trackAnimatedStyle = useMemo(
-    () => ({
+  const trackAnimatedStyle = useMemo(() => {
+    if (disabled) {
+      return [
+        styles.trackDisabled,
+        { borderColor: hasError ? ERROR_COLOR : 'transparent' },
+      ];
+    }
+    return {
       backgroundColor,
       borderColor: hasError ? ERROR_COLOR : 'transparent',
-    }),
-    [backgroundColor, hasError],
-  );
+    };
+  }, [backgroundColor, disabled, hasError]);
 
-  const knobAnimatedStyle = useMemo(
-    () => ({
+  const knobAnimatedStyle = useMemo(() => {
+    if (disabled) {
+      return [styles.knobDisabled, { transform: [{ translateX }] }];
+    }
+    return {
       backgroundColor: knobColor,
       transform: [{ translateX }],
-    }),
-    [knobColor, translateX],
-  );
+    };
+  }, [disabled, knobColor, translateX]);
+
+  const optionRowStyles = buildOptionRowStyles(optionRowStyle, disabled);
+  const optionLabelStyles = buildOptionLabelStyles(optionLabelStyle, disabled);
+  const handlePress = () => {
+    onPress(value);
+  };
 
   return (
     <Pressable
       accessibilityRole='checkbox'
       accessibilityState={accessibilityState}
-      onPress={onPress}
-      style={[styles.optionRow, optionRowStyle]}
+      disabled={disabled}
+      onPress={handlePress}
+      style={optionRowStyles}
     >
       <Animated.View style={[styles.track, trackAnimatedStyle, trackStyle]}>
         <Animated.View style={[styles.knob, knobAnimatedStyle, knobStyle]} />
       </Animated.View>
-      <Text style={[styles.optionLabel, optionLabelStyle]}>{label}</Text>
+      <Text style={optionLabelStyles}>{label}</Text>
     </Pressable>
   );
 };
 
-const CheckBoxCustom = <TFieldValues extends FieldValues>({
-  activeColor: activeColorProp,
-  containerStyle,
-  control,
-  errorText,
-  inactiveColor: inactiveColorProp,
-  knobColor: knobColorProp,
-  label,
-  labelStyle,
-  name,
-  optionListStyle,
-  optionRowStyle,
-  optionLabelStyle,
-  options,
-  rules,
-  trackStyle,
-  knobStyle,
-}: TypeCheckBoxCustom<TFieldValues>) => {
+// eslint-disable-next-line complexity
+function CheckBoxCustom<TFieldValues extends FieldValues>(
+  props: Readonly<TypeCheckBoxCustom<TFieldValues>>,
+) {
+  const {
+    activeColor: activeColorProp,
+    containerStyle,
+    control,
+    errorText,
+    inactiveColor: inactiveColorProp,
+    knobColor: knobColorProp,
+    label,
+    labelStyle,
+    name,
+    optionListStyle,
+    optionRowStyle,
+    optionLabelStyle,
+    options,
+    rules,
+    trackStyle,
+    knobStyle,
+    disabled = false,
+  } = props;
   const {
     field: { value, onChange },
   } = useController({ control, name, rules });
 
-  const selectedValues = useMemo(() => (Array.isArray(value) ? (value as string[]) : []), [value]);
+  const selectedValues = normalizeSelectedValues(value);
 
   const hasError = errorText?.message != null;
 
@@ -113,45 +136,32 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   const inactiveColor = inactiveColorProp ?? '#d1d5db';
   const knobColor = knobColorProp ?? '#ffffff';
 
-  const handleToggle = (optionValue: string) => {
-    if (selectedValues.includes(optionValue)) {
-      onChange(selectedValues.filter((selected) => selected !== optionValue));
-      return;
-    }
-    onChange([...selectedValues, optionValue]);
-  };
+  const labelStyles = buildLabelStyles(labelStyle, disabled);
+  const optionListStyles = buildOptionListStyles(optionListStyle);
+  const handleToggle = createToggleHandler(disabled, selectedValues, onChange);
+
+  const toggleOptions = buildToggleOptions(options, {
+    activeColor,
+    disabled,
+    handleToggle,
+    hasError,
+    inactiveColor,
+    knobColor,
+    knobStyle,
+    optionLabelStyle,
+    optionRowStyle,
+    selectedValues,
+    trackStyle,
+  });
 
   return (
     <View style={[styles.container, containerStyle]}>
-      <Text style={[styles.label, labelStyle]}>{label}</Text>
-      <View style={[styles.optionList, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValues.includes(option.value);
-          return (
-            <ToggleCheckOption
-              accessibilityState={{ checked: isSelected }}
-              activeColor={activeColor}
-              hasError={hasError}
-              inactiveColor={inactiveColor}
-              isSelected={isSelected}
-              key={option.key ?? option.value}
-              knobColor={knobColor}
-              knobStyle={knobStyle}
-              label={option.label}
-              onPress={() => {
-                handleToggle(option.value);
-              }}
-              optionLabelStyle={optionLabelStyle}
-              optionRowStyle={optionRowStyle}
-              trackStyle={trackStyle}
-            />
-          );
-        })}
-      </View>
+      <Text style={labelStyles}>{label}</Text>
+      <View style={optionListStyles}>{toggleOptions}</View>
       <ErrorText {...errorText} />
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -191,6 +201,153 @@ const styles = StyleSheet.create({
   optionLabel: {
     fontSize: 14,
   },
+  disabledLabel: {
+    color: '#ccc',
+  },
+  disabledRow: {
+    opacity: 0.8,
+  },
+  disabledOptionLabel: {
+    color: '#ccc',
+  },
+  trackDisabled: {
+    backgroundColor: '#ccc',
+  },
+  knobDisabled: {
+    backgroundColor: '#ccc',
+  },
 });
+
+const normalizeSelectedValues = (rawValue: unknown): string[] => {
+  if (Array.isArray(rawValue)) {
+    return rawValue as string[];
+  }
+  return [];
+};
+
+const toggleValues = (selectedValues: string[], optionValue: string): string[] => {
+  if (selectedValues.includes(optionValue)) {
+    return selectedValues.filter((selected) => selected !== optionValue);
+  }
+  return [...selectedValues, optionValue];
+};
+
+const createToggleHandler = (
+  disabled: boolean,
+  selectedValues: string[],
+  onChange: (values: string[]) => void,
+): ((optionValue: string) => void) => {
+  if (disabled) {
+    return () => {};
+  }
+
+  return (optionValue: string) => {
+    onChange(toggleValues(selectedValues, optionValue));
+  };
+};
+
+type BuildToggleOptionsContext = {
+  activeColor: string;
+  disabled: boolean;
+  handleToggle: (value: string) => void;
+  hasError: boolean;
+  inactiveColor: string;
+  knobColor: string;
+  knobStyle: StyleProp<ViewStyle> | undefined;
+  optionLabelStyle: StyleProp<TextStyle> | undefined;
+  optionRowStyle: StyleProp<ViewStyle> | undefined;
+  selectedValues: string[];
+  trackStyle: StyleProp<ViewStyle> | undefined;
+};
+
+const buildToggleOptions = (
+  options: TypeCheckBoxCustom<FieldValues>['options'],
+  context: BuildToggleOptionsContext,
+): ReactElement[] =>
+  options.map((option) => {
+    const isSelected = context.selectedValues.includes(option.value);
+    return (
+      <ToggleCheckOption
+        accessibilityState={{ checked: isSelected }}
+        activeColor={context.activeColor}
+        disabled={context.disabled}
+        hasError={context.hasError}
+        inactiveColor={context.inactiveColor}
+        isSelected={isSelected}
+        key={option.key ?? option.value}
+        knobColor={context.knobColor}
+        knobStyle={context.knobStyle}
+        label={option.label}
+        onPress={context.handleToggle}
+        optionLabelStyle={context.optionLabelStyle}
+        optionRowStyle={context.optionRowStyle}
+        trackStyle={context.trackStyle}
+        value={option.value}
+      />
+    );
+  });
+
+const buildLabelStyles = (
+  customLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [styles.label];
+
+  if (customLabelStyle != null) {
+    stylesList.push(customLabelStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledLabel);
+  }
+
+  return stylesList;
+};
+
+const buildOptionListStyles = (
+  optionListStyle: StyleProp<ViewStyle> | undefined,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.optionList];
+
+  if (optionListStyle != null) {
+    stylesList.push(optionListStyle);
+  }
+
+  return stylesList;
+};
+
+const buildOptionRowStyles = (
+  optionRowStyle: StyleProp<ViewStyle> | undefined,
+  disabled: boolean,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.optionRow];
+
+  if (optionRowStyle != null) {
+    stylesList.push(optionRowStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledRow);
+  }
+
+  return stylesList;
+};
+
+const buildOptionLabelStyles = (
+  optionLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [styles.optionLabel];
+
+  if (optionLabelStyle != null) {
+    stylesList.push(optionLabelStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledOptionLabel);
+  }
+
+  return stylesList;
+};
 
 export default CheckBoxCustom;

--- a/app/components/form/_input.tsx
+++ b/app/components/form/_input.tsx
@@ -5,6 +5,7 @@ import ErrorText from './_errorText';
 
 import type { TypeInput } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
+import type { StyleProp, TextStyle } from 'react-native';
 
 /* -----------------------------------------------
  * インプット項目
@@ -18,24 +19,29 @@ const Input = <TFieldValues extends FieldValues>({
   name,
   rules,
   style,
+  disabled = false,
   ...textInputProps
 }: TypeInput<TFieldValues>) => {
   const {
     field: { onBlur, onChange, value },
   } = useController({ control, name, rules });
 
-  const inputValue = typeof value === 'string' ? value : '';
+  const inputValue = normalizeInputValue(value);
   const hasError = errorText?.message != null;
+  const placeholderColor = getPlaceholderColor(disabled);
+  const labelStyles = buildLabelStyles(disabled);
+  const inputStylesList = buildInputStyles(hasError, disabled, style);
 
   return (
     <View style={[inputStyles.container, containerStyle]}>
-      <Text style={inputStyles.label}>{label}</Text>
+      <Text style={labelStyles}>{label}</Text>
       <TextInput
         {...textInputProps}
+        editable={!disabled}
         onBlur={onBlur}
         onChangeText={onChange}
-        placeholderTextColor='#9e9e9e'
-        style={[inputStyles.input, hasError ? inputStyles.inputError : null, style]}
+        placeholderTextColor={placeholderColor}
+        style={inputStylesList}
         value={inputValue}
       />
       <ErrorText {...errorText} />
@@ -63,6 +69,60 @@ const inputStyles = StyleSheet.create({
   inputError: {
     borderColor: '#e53935',
   },
+  inputDisabled: {
+    backgroundColor: '#ccc',
+    borderColor: '#ccc',
+    color: '#ccc',
+  },
+  disabledLabel: {
+    color: '#ccc',
+  },
 });
+
+const buildLabelStyles = (disabled: boolean): StyleProp<TextStyle>[] => {
+  const styles: StyleProp<TextStyle>[] = [inputStyles.label];
+
+  if (disabled) {
+    styles.push(inputStyles.disabledLabel);
+  }
+
+  return styles;
+};
+
+const buildInputStyles = (
+  hasError: boolean,
+  disabled: boolean,
+  customStyle: StyleProp<TextStyle> | undefined,
+): StyleProp<TextStyle>[] => {
+  const styles: StyleProp<TextStyle>[] = [inputStyles.input];
+
+  if (hasError) {
+    styles.push(inputStyles.inputError);
+  }
+
+  if (customStyle != null) {
+    styles.push(customStyle);
+  }
+
+  if (disabled) {
+    styles.push(inputStyles.inputDisabled);
+  }
+
+  return styles;
+};
+
+const getPlaceholderColor = (disabled: boolean): string => {
+  if (disabled) {
+    return '#ccc';
+  }
+  return '#9e9e9e';
+};
+
+const normalizeInputValue = (rawValue: unknown): string => {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
+  return '';
+};
 
 export default Input;

--- a/app/components/form/_radioBox.tsx
+++ b/app/components/form/_radioBox.tsx
@@ -5,6 +5,7 @@ import ErrorText from './_errorText';
 
 import type { TypeRadioBox } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * ラヂオボックス項目
@@ -21,40 +22,41 @@ const RadioBox = <TFieldValues extends FieldValues>({
   optionRowStyle,
   options,
   rules,
+  disabled = false,
 }: TypeRadioBox<TFieldValues>) => {
   const {
     field: { value, onChange },
   } = useController({ control, name, rules });
 
-  const selectedValue = typeof value === 'string' ? value : '';
+  const selectedValue = getSelectedValue(value);
   const hasError = errorText?.message != null;
+  const labelStyles = buildLabelStyles(labelStyle, disabled);
+  const optionListStyles = buildOptionListStyles(optionListStyle);
+  const optionRowStyles = buildOptionRowStyles(optionRowStyle, disabled);
+  const optionTextStyles = getOptionTextStyles(disabled);
 
   return (
     <View style={[styles.container, containerStyle]}>
-      <Text style={[styles.label, labelStyle]}>{label}</Text>
-      <View style={[styles.radioGroup, optionListStyle]}>
+      <Text style={labelStyles}>{label}</Text>
+      <View style={optionListStyles}>
         {options.map((option) => {
           const isSelected = selectedValue === option.value;
+          const radioOuterStyles = buildRadioOuterStyles(isSelected, hasError, disabled);
           return (
             <Pressable
               accessibilityRole='radio'
               accessibilityState={{ selected: isSelected }}
+              disabled={disabled}
               key={option.key ?? option.value}
               onPress={() => {
                 onChange(option.value);
               }}
-              style={[styles.radioRow, optionRowStyle]}
+              style={optionRowStyles}
             >
-              <View
-                style={[
-                  styles.radioOuter,
-                  isSelected ? styles.radioOuterSelected : null,
-                  hasError ? styles.radioOuterError : null,
-                ]}
-              >
-                {isSelected ? <View style={styles.radioInner} /> : null}
+              <View style={radioOuterStyles}>
+                {isSelected ? <View style={buildRadioInnerStyles(disabled)} /> : null}
               </View>
-              <Text>{option.label}</Text>
+              <Text style={optionTextStyles}>{option.label}</Text>
             </Pressable>
           );
         })}
@@ -102,6 +104,117 @@ const styles = StyleSheet.create({
   radioOuterError: {
     borderColor: '#e53935',
   },
+  radioOuterDisabled: {
+    backgroundColor: '#ccc',
+    borderColor: '#ccc',
+  },
+  radioInnerDisabled: {
+    backgroundColor: '#ccc',
+  },
+  disabledLabel: {
+    color: '#ccc',
+  },
+  disabledRow: {
+    opacity: 0.8,
+  },
+  disabledOptionText: {
+    color: '#ccc',
+  },
 });
+
+const getSelectedValue = (rawValue: unknown): string => {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
+  return '';
+};
+
+const buildLabelStyles = (
+  customLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [styles.label];
+
+  if (customLabelStyle != null) {
+    stylesList.push(customLabelStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledLabel);
+  }
+
+  return stylesList;
+};
+
+const buildOptionListStyles = (
+  optionListStyle: StyleProp<ViewStyle> | undefined,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.radioGroup];
+
+  if (optionListStyle != null) {
+    stylesList.push(optionListStyle);
+  }
+
+  return stylesList;
+};
+
+const buildOptionRowStyles = (
+  optionRowStyle: StyleProp<ViewStyle> | undefined,
+  disabled: boolean,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.radioRow];
+
+  if (optionRowStyle != null) {
+    stylesList.push(optionRowStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledRow);
+  }
+
+  return stylesList;
+};
+
+const buildRadioOuterStyles = (
+  isSelected: boolean,
+  hasError: boolean,
+  disabled: boolean,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.radioOuter];
+
+  if (isSelected) {
+    stylesList.push(styles.radioOuterSelected);
+  }
+
+  if (hasError) {
+    stylesList.push(styles.radioOuterError);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.radioOuterDisabled);
+  }
+
+  return stylesList;
+};
+
+const buildRadioInnerStyles = (disabled: boolean): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.radioInner];
+
+  if (disabled) {
+    stylesList.push(styles.radioInnerDisabled);
+  }
+
+  return stylesList;
+};
+
+const getOptionTextStyles = (disabled: boolean): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [];
+
+  if (disabled) {
+    stylesList.push(styles.disabledOptionText);
+  }
+
+  return stylesList;
+};
 
 export default RadioBox;

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -5,7 +5,9 @@ import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 import ErrorText from './_errorText';
 
 import type { TypeRadioBoxCustom, TypeToggleRadioOption } from '../../lib/types/typeComponents';
+import type { ReactElement } from 'react';
 import type { FieldValues } from 'react-hook-form';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * ラヂオボックスカスタム項目
@@ -31,6 +33,8 @@ const ToggleRadioOption = ({
   optionLabelStyle,
   trackStyle,
   knobStyle,
+  disabled,
+  value,
 }: TypeToggleRadioOption) => {
   const animation = useRef(new Animated.Value(isSelected ? 1 : 0)).current;
 
@@ -52,60 +56,79 @@ const ToggleRadioOption = ({
     outputRange: [KNOB_MARGIN, TRACK_WIDTH - KNOB_SIZE - KNOB_MARGIN],
   });
 
-  const trackAnimatedStyle = useMemo(
-    () => ({
+  const trackAnimatedStyle = useMemo(() => {
+    if (disabled) {
+      return [
+        styles.trackDisabled,
+        { borderColor: hasError ? ERROR_COLOR : 'transparent' },
+      ];
+    }
+    return {
       backgroundColor,
       borderColor: hasError ? ERROR_COLOR : 'transparent',
-    }),
-    [backgroundColor, hasError],
-  );
+    };
+  }, [backgroundColor, disabled, hasError]);
 
-  const knobAnimatedStyle = useMemo(
-    () => ({
+  const knobAnimatedStyle = useMemo(() => {
+    if (disabled) {
+      return [styles.knobDisabled, { transform: [{ translateX }] }];
+    }
+    return {
       backgroundColor: knobColor,
       transform: [{ translateX }],
-    }),
-    [knobColor, translateX],
-  );
+    };
+  }, [disabled, knobColor, translateX]);
+
+  const optionRowStyles = buildOptionRowStyles(optionRowStyle, disabled);
+  const optionLabelStyles = buildOptionLabelStyles(optionLabelStyle, disabled);
+  const handlePress = () => {
+    onPress(value);
+  };
 
   return (
     <Pressable
       accessibilityRole='radio'
       accessibilityState={accessibilityState}
-      onPress={onPress}
-      style={[styles.optionRow, optionRowStyle]}
+      disabled={disabled}
+      onPress={handlePress}
+      style={optionRowStyles}
     >
       <Animated.View style={[styles.track, trackAnimatedStyle, trackStyle]}>
         <Animated.View style={[styles.knob, knobAnimatedStyle, knobStyle]} />
       </Animated.View>
-      <Text style={[styles.optionLabel, optionLabelStyle]}>{label}</Text>
+      <Text style={optionLabelStyles}>{label}</Text>
     </Pressable>
   );
 };
 
-const RadioBoxCustom = <TFieldValues extends FieldValues>({
-  activeColor: activeColorProp,
-  containerStyle,
-  control,
-  errorText,
-  inactiveColor: inactiveColorProp,
-  knobColor: knobColorProp,
-  label,
-  labelStyle,
-  name,
-  optionListStyle,
-  optionRowStyle,
-  optionLabelStyle,
-  options,
-  rules,
-  trackStyle,
-  knobStyle,
-}: TypeRadioBoxCustom<TFieldValues>) => {
+// eslint-disable-next-line complexity
+function RadioBoxCustom<TFieldValues extends FieldValues>(
+  props: Readonly<TypeRadioBoxCustom<TFieldValues>>,
+) {
+  const {
+    activeColor: activeColorProp,
+    containerStyle,
+    control,
+    errorText,
+    inactiveColor: inactiveColorProp,
+    knobColor: knobColorProp,
+    label,
+    labelStyle,
+    name,
+    optionListStyle,
+    optionRowStyle,
+    optionLabelStyle,
+    options,
+    rules,
+    trackStyle,
+    knobStyle,
+    disabled = false,
+  } = props;
   const {
     field: { value, onChange },
   } = useController({ control, name, rules });
 
-  const selectedValue = useMemo(() => (typeof value === 'string' ? value : ''), [value]);
+  const selectedValue = normalizeSelectedValue(value);
 
   const hasError = errorText?.message != null;
 
@@ -113,37 +136,32 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
   const inactiveColor = inactiveColorProp ?? '#d1d5db';
   const knobColor = knobColorProp ?? '#ffffff';
 
+  const labelStyles = buildLabelStyles(labelStyle, disabled);
+  const optionListStyles = buildOptionListStyles(optionListStyle);
+  const handleSelect = createSelectHandler(disabled, onChange);
+
+  const toggleOptions = buildRadioOptions(options, {
+    activeColor,
+    disabled,
+    handleSelect,
+    hasError,
+    inactiveColor,
+    knobColor,
+    knobStyle,
+    optionLabelStyle,
+    optionRowStyle,
+    selectedValue,
+    trackStyle,
+  });
+
   return (
     <View style={[styles.container, containerStyle]}>
-      <Text style={[styles.label, labelStyle]}>{label}</Text>
-      <View style={[styles.optionList, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValue === option.value;
-          return (
-            <ToggleRadioOption
-              accessibilityState={{ selected: isSelected }}
-              activeColor={activeColor}
-              hasError={hasError}
-              inactiveColor={inactiveColor}
-              isSelected={isSelected}
-              key={option.key ?? option.value}
-              knobColor={knobColor}
-              knobStyle={knobStyle}
-              label={option.label}
-              onPress={() => {
-                onChange(option.value);
-              }}
-              optionLabelStyle={optionLabelStyle}
-              optionRowStyle={optionRowStyle}
-              trackStyle={trackStyle}
-            />
-          );
-        })}
-      </View>
+      <Text style={labelStyles}>{label}</Text>
+      <View style={optionListStyles}>{toggleOptions}</View>
       <ErrorText {...errorText} />
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -183,6 +201,145 @@ const styles = StyleSheet.create({
   optionLabel: {
     fontSize: 14,
   },
+  disabledLabel: {
+    color: '#ccc',
+  },
+  disabledRow: {
+    opacity: 0.8,
+  },
+  disabledOptionLabel: {
+    color: '#ccc',
+  },
+  trackDisabled: {
+    backgroundColor: '#ccc',
+  },
+  knobDisabled: {
+    backgroundColor: '#ccc',
+  },
 });
+
+const normalizeSelectedValue = (rawValue: unknown): string => {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
+  return '';
+};
+
+const buildLabelStyles = (
+  customLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [styles.label];
+
+  if (customLabelStyle != null) {
+    stylesList.push(customLabelStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledLabel);
+  }
+
+  return stylesList;
+};
+
+const buildOptionListStyles = (
+  optionListStyle: StyleProp<ViewStyle> | undefined,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.optionList];
+
+  if (optionListStyle != null) {
+    stylesList.push(optionListStyle);
+  }
+
+  return stylesList;
+};
+
+const buildOptionRowStyles = (
+  optionRowStyle: StyleProp<ViewStyle> | undefined,
+  disabled: boolean,
+): StyleProp<ViewStyle>[] => {
+  const stylesList: StyleProp<ViewStyle>[] = [styles.optionRow];
+
+  if (optionRowStyle != null) {
+    stylesList.push(optionRowStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledRow);
+  }
+
+  return stylesList;
+};
+
+const buildOptionLabelStyles = (
+  optionLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const stylesList: StyleProp<TextStyle>[] = [styles.optionLabel];
+
+  if (optionLabelStyle != null) {
+    stylesList.push(optionLabelStyle);
+  }
+
+  if (disabled) {
+    stylesList.push(styles.disabledOptionLabel);
+  }
+
+  return stylesList;
+};
+
+const createSelectHandler = (
+  disabled: boolean,
+  onChange: (value: string) => void,
+): ((optionValue: string) => void) => {
+  if (disabled) {
+    return () => {};
+  }
+
+  return (optionValue: string) => {
+    onChange(optionValue);
+  };
+};
+
+type BuildRadioOptionsContext = {
+  activeColor: string;
+  disabled: boolean;
+  handleSelect: (value: string) => void;
+  hasError: boolean;
+  inactiveColor: string;
+  knobColor: string;
+  knobStyle: StyleProp<ViewStyle> | undefined;
+  optionLabelStyle: StyleProp<TextStyle> | undefined;
+  optionRowStyle: StyleProp<ViewStyle> | undefined;
+  selectedValue: string;
+  trackStyle: StyleProp<ViewStyle> | undefined;
+};
+
+const buildRadioOptions = (
+  options: TypeRadioBoxCustom<FieldValues>['options'],
+  context: BuildRadioOptionsContext,
+): ReactElement[] =>
+  options.map((option) => {
+    const isSelected = context.selectedValue === option.value;
+    return (
+      <ToggleRadioOption
+        accessibilityState={{ selected: isSelected }}
+        activeColor={context.activeColor}
+        disabled={context.disabled}
+        hasError={context.hasError}
+        inactiveColor={context.inactiveColor}
+        isSelected={isSelected}
+        key={option.key ?? option.value}
+        knobColor={context.knobColor}
+        knobStyle={context.knobStyle}
+        label={option.label}
+        onPress={context.handleSelect}
+        optionLabelStyle={context.optionLabelStyle}
+        optionRowStyle={context.optionRowStyle}
+        trackStyle={context.trackStyle}
+        value={option.value}
+      />
+    );
+  });
 
 export default RadioBoxCustom;

--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -6,7 +6,7 @@ import RNPickerSelect from 'react-native-picker-select';
 import ErrorText from './_errorText';
 
 import type { TypeSelectBox, TypeSelectBoxOption } from '../../lib/types/typeComponents';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, RefObject } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
@@ -14,22 +14,27 @@ import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
  * セレクトボックス項目
  * ----------------------------------------------- */
 
-const SelectBox = <TFieldValues extends FieldValues>({
-  containerStyle,
-  control,
-  doneText = '完了',
-  errorText,
-  label,
-  labelStyle,
-  name,
-  options,
-  pickerSelectStyles,
-  placeholder = '選択してください',
-  placeholderTextStyle,
-  rules,
-  triggerStyle,
-  valueTextStyle,
-}: TypeSelectBox<TFieldValues>) => {
+// eslint-disable-next-line complexity
+function SelectBox<TFieldValues extends FieldValues>(
+  props: Readonly<TypeSelectBox<TFieldValues>>,
+) {
+  const {
+    containerStyle,
+    control,
+    doneText = '完了',
+    errorText,
+    label,
+    labelStyle,
+    name,
+    options,
+    pickerSelectStyles,
+    placeholder = '選択してください',
+    placeholderTextStyle,
+    rules,
+    triggerStyle,
+    valueTextStyle,
+    disabled = false,
+  } = props;
   const pickerRef = useRef<RNPickerSelect | null>(null);
 
   const {
@@ -43,38 +48,40 @@ const SelectBox = <TFieldValues extends FieldValues>({
   const isPlaceholder = selectedOption == null;
   const displayLabel = getDisplayLabel(selectedOption, placeholder);
 
-  const triggerStyles = buildTriggerStyles(triggerStyle, hasError);
+  const triggerStyles = buildTriggerStyles(triggerStyle, hasError, disabled);
   const triggerTextStyles = buildTriggerTextStyles(
     isPlaceholder,
     placeholderTextStyle,
     valueTextStyle,
+    disabled,
   );
-
-  const openPicker = () => {
-    Keyboard.dismiss();
-    pickerRef.current?.togglePicker(true);
-  };
-
-  const handleValueChange = (selected: string | null) => {
-    onChange(selected ?? '');
-  };
+  const labelStyles = buildLabelStyles(labelStyle, disabled);
+  const openPicker = buildPickerOpener(disabled, pickerRef);
+  const handleValueChange = createValueChangeHandler(onChange);
+  const assignPickerRef = createPickerRefAssigner(pickerRef);
 
   return (
     <View style={[defaultPickerStyles.container, containerStyle]}>
-      <Text style={[defaultPickerStyles.label, labelStyle]}>{label}</Text>
+      <Text style={labelStyles}>
+        {label}
+      </Text>
 
-      <Pressable accessibilityRole='button' onPress={openPicker} style={triggerStyles}>
+      <Pressable
+        accessibilityRole='button'
+        disabled={disabled}
+        onPress={openPicker}
+        style={triggerStyles}
+      >
         <Text style={triggerTextStyles}>{displayLabel}</Text>
       </Pressable>
 
       <RNPickerSelect
+        disabled={disabled}
         doneText={doneText}
         items={options}
         onValueChange={handleValueChange}
         placeholder={{ label: placeholder, value: '' }}
-        ref={(ref) => {
-          pickerRef.current = ref;
-        }}
+        ref={assignPickerRef}
         style={pickerSelectStyles ?? basePickerSelectStyles}
         useNativeAndroidPickerStyle={false}
         value={toPickerValue(selectedValue)}
@@ -83,7 +90,7 @@ const SelectBox = <TFieldValues extends FieldValues>({
       <ErrorText {...errorText} />
     </View>
   );
-};
+}
 
 const defaultPickerStyles = StyleSheet.create({
   selectTrigger: {
@@ -105,6 +112,9 @@ const defaultPickerStyles = StyleSheet.create({
     color: '#9e9e9e',
     fontSize: 14,
   },
+  selectTextDisabled: {
+    color: '#ccc',
+  },
   label: {
     fontSize: 14,
     fontWeight: '500',
@@ -116,7 +126,31 @@ const defaultPickerStyles = StyleSheet.create({
   inputError: {
     borderColor: '#e53935',
   },
+  selectTriggerDisabled: {
+    backgroundColor: '#ccc',
+    borderColor: '#ccc',
+  },
+  disabledLabel: {
+    color: '#ccc',
+  },
 });
+
+const buildLabelStyles = (
+  customLabelStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
+): StyleProp<TextStyle>[] => {
+  const styles: StyleProp<TextStyle>[] = [defaultPickerStyles.label];
+
+  if (customLabelStyle != null) {
+    styles.push(customLabelStyle);
+  }
+
+  if (disabled) {
+    styles.push(defaultPickerStyles.disabledLabel);
+  }
+
+  return styles;
+};
 
 const basePickerSelectStyles = {
   inputIOS: {
@@ -168,6 +202,7 @@ const ensureString = (rawValue: unknown): string => {
 const buildTriggerStyles = (
   triggerStyle: StyleProp<ViewStyle> | undefined,
   hasError: boolean,
+  disabled: boolean,
 ): StyleProp<ViewStyle>[] => {
   const styles: StyleProp<ViewStyle>[] = [defaultPickerStyles.selectTrigger];
 
@@ -179,6 +214,10 @@ const buildTriggerStyles = (
     styles.push(defaultPickerStyles.inputError);
   }
 
+  if (disabled) {
+    styles.push(defaultPickerStyles.selectTriggerDisabled);
+  }
+
   return styles;
 };
 
@@ -186,20 +225,21 @@ const buildTriggerTextStyles = (
   isPlaceholder: boolean,
   placeholderTextStyle: StyleProp<TextStyle> | undefined,
   valueTextStyle: StyleProp<TextStyle> | undefined,
+  disabled: boolean,
 ): StyleProp<TextStyle>[] => {
-  const styles: StyleProp<TextStyle>[] = [];
+  const baseStyle = isPlaceholder
+    ? defaultPickerStyles.selectPlaceholderText
+    : defaultPickerStyles.selectValueText;
 
-  if (isPlaceholder) {
-    styles.push(defaultPickerStyles.selectPlaceholderText);
-    if (placeholderTextStyle != null) {
-      styles.push(placeholderTextStyle);
-    }
-    return styles;
+  const styles: StyleProp<TextStyle>[] = [baseStyle];
+  const customStyle = isPlaceholder ? placeholderTextStyle : valueTextStyle;
+
+  if (customStyle != null) {
+    styles.push(customStyle);
   }
 
-  styles.push(defaultPickerStyles.selectValueText);
-  if (valueTextStyle != null) {
-    styles.push(valueTextStyle);
+  if (disabled) {
+    styles.push(defaultPickerStyles.selectTextDisabled);
   }
 
   return styles;
@@ -220,6 +260,36 @@ const toPickerValue = (value: string): string | null => {
     return null;
   }
   return value;
+};
+
+const buildPickerOpener = (
+  disabled: boolean,
+  pickerRef: RefObject<RNPickerSelect | null>,
+): (() => void) => {
+  if (disabled) {
+    return () => {};
+  }
+
+  return () => {
+    Keyboard.dismiss();
+    pickerRef.current?.togglePicker(true);
+  };
+};
+
+const createValueChangeHandler = (
+  onChange: (value: string) => void,
+): ((selected: string | null) => void) => {
+  return (selected) => {
+    onChange(selected ?? '');
+  };
+};
+
+const createPickerRefAssigner = (
+  pickerRef: RefObject<RNPickerSelect | null>,
+): ((ref: RNPickerSelect | null) => void) => {
+  return (ref) => {
+    pickerRef.current = ref;
+  };
 };
 
 export default SelectBox;

--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -35,6 +35,7 @@ type TypeToggleCustomBase<TFieldValues extends FieldValues> = {
   activeColor?: string;
   inactiveColor?: string;
   knobColor?: string;
+  disabled?: boolean;
 };
 
 /* -----------------------------------------------
@@ -51,6 +52,7 @@ export type TypeCheckBox<TFieldValues extends FieldValues> = {
   labelStyle?: StyleProp<TextStyle>;
   optionListStyle?: StyleProp<ViewStyle>;
   optionRowStyle?: StyleProp<ViewStyle>;
+  disabled?: boolean;
 };
 
 /* -----------------------------------------------
@@ -62,7 +64,7 @@ export type TypeCheckBoxCustom<TFieldValues extends FieldValues> =
 export type TypeToggleCheckOption = {
   label: string;
   isSelected: boolean;
-  onPress: () => void;
+  onPress: (value: string) => void;
   accessibilityState: PressableProps['accessibilityState'];
   hasError: boolean;
   activeColor: string;
@@ -72,6 +74,8 @@ export type TypeToggleCheckOption = {
   optionLabelStyle: TypeCheckBoxCustom<FieldValues>['optionLabelStyle'];
   trackStyle: TypeCheckBoxCustom<FieldValues>['trackStyle'];
   knobStyle: TypeCheckBoxCustom<FieldValues>['knobStyle'];
+  disabled: boolean;
+  value: string;
 };
 
 /* -----------------------------------------------
@@ -90,6 +94,7 @@ export type TypeInput<TFieldValues extends FieldValues> = {
   errorText?: TypeErrorText | FieldError;
   containerStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<TextStyle>;
+  disabled?: boolean;
 } & Omit<TextInputProps, 'onBlur' | 'onChangeText' | 'value' | 'style'>;
 
 /* -----------------------------------------------
@@ -106,6 +111,7 @@ export type TypeRadioBox<TFieldValues extends FieldValues> = {
   labelStyle?: StyleProp<TextStyle>;
   optionListStyle?: StyleProp<ViewStyle>;
   optionRowStyle?: StyleProp<ViewStyle>;
+  disabled?: boolean;
 };
 
 /* -----------------------------------------------
@@ -117,7 +123,7 @@ export type TypeRadioBoxCustom<TFieldValues extends FieldValues> =
 export type TypeToggleRadioOption = {
   label: string;
   isSelected: boolean;
-  onPress: () => void;
+  onPress: (value: string) => void;
   accessibilityState: PressableProps['accessibilityState'];
   hasError: boolean;
   activeColor: string;
@@ -127,6 +133,8 @@ export type TypeToggleRadioOption = {
   optionLabelStyle: TypeRadioBoxCustom<FieldValues>['optionLabelStyle'];
   trackStyle: TypeRadioBoxCustom<FieldValues>['trackStyle'];
   knobStyle: TypeRadioBoxCustom<FieldValues>['knobStyle'];
+  disabled: boolean;
+  value: string;
 };
 
 /* -----------------------------------------------
@@ -151,6 +159,7 @@ export type TypeSelectBox<TFieldValues extends FieldValues> = {
   valueTextStyle?: StyleProp<TextStyle>;
   placeholderTextStyle?: StyleProp<TextStyle>;
   pickerSelectStyles?: PickerStyle;
+  disabled?: boolean;
 };
 
 /* -----------------------------------------------


### PR DESCRIPTION
## Summary
- add optional disabled support across the shared form components and their type definitions
- ensure disabled interactions bail out early and render with the requested #ccc styling
- refactor helpers to keep label, option, and trigger styles consistent when disabled

## Testing
- yarn lint *(fails: workspace package missing from lockfile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910382f98688324bb13c552c3cb9592)