### PR TITLE
refactor: use Controller for form components

### DIFF
--- a/app/components/form/_checkBox.tsx
+++ b/app/components/form/_checkBox.tsx
@@ -1,4 +1,4 @@
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
@@ -23,58 +23,66 @@ const CheckBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeCheckBox<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValues = Array.isArray(value) ? (value as string[]) : [];
   const hasError = errorText?.message != null;
-
-  const handleToggle = (optionValue: string) => {
-    if (selectedValues.includes(optionValue)) {
-      onChange(selectedValues.filter((selected) => selected !== optionValue));
-      return;
-    }
-    onChange([...selectedValues, optionValue]);
-  };
 
   const optionLabelStyle = (disabled?: boolean) => {
     return disabled === true ? styles.checkBoxTextDisabled : null;
   };
 
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
-      <View style={[styles.checkBoxGroup, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValues.includes(option.value);
-          const isDisabled = () => option.disabled === true || disabled;
-          return (
-            <Pressable
-              accessibilityRole='checkbox'
-              accessibilityState={{ checked: isSelected }}
-              disabled={isDisabled()}
-              key={option.key ?? option.value}
-              onPress={() => {
-                handleToggle(option.value);
-              }}
-              style={[styles.checkBoxRow, optionRowStyle]}
-            >
-              <View
-                style={[
-                  styles.checkBoxBase,
-                  isSelected ? styles.checkBoxChecked : null,
-                  hasError ? styles.checkBoxError : null,
-                  isDisabled() ? styles.checkBoxDisabled : null,
-                ]}
-              />
-              <Text style={optionLabelStyle(isDisabled())}>{option.label}</Text>
-            </Pressable>
-          );
-        })}
-      </View>
-      <ErrorText {...errorText} />
-    </View>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+      }) => {
+        const selectedValues = Array.isArray(value) ? (value as string[]) : [];
+
+        const handleToggle = (optionValue: string) => {
+          if (selectedValues.includes(optionValue)) {
+            onChange(selectedValues.filter((selected) => selected !== optionValue));
+            return;
+          }
+          onChange([...selectedValues, optionValue]);
+        };
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+            <View style={[styles.checkBoxGroup, optionListStyle]}>
+              {options.map((option) => {
+                const isSelected = selectedValues.includes(option.value);
+                const isDisabled = () => option.disabled === true || disabled;
+                return (
+                  <Pressable
+                    accessibilityRole='checkbox'
+                    accessibilityState={{ checked: isSelected }}
+                    disabled={isDisabled()}
+                    key={option.key ?? option.value}
+                    onPress={() => {
+                      handleToggle(option.value);
+                    }}
+                    style={[styles.checkBoxRow, optionRowStyle]}
+                  >
+                    <View
+                      style={[
+                        styles.checkBoxBase,
+                        isSelected ? styles.checkBoxChecked : null,
+                        hasError ? styles.checkBoxError : null,
+                        isDisabled() ? styles.checkBoxDisabled : null,
+                      ]}
+                    />
+                    <Text style={optionLabelStyle(isDisabled())}>{option.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
@@ -108,57 +108,64 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeCheckBoxCustom<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValues = useMemo(() => (Array.isArray(value) ? (value as string[]) : []), [value]);
-
   const hasError = errorText?.message != null;
 
   const activeColor = activeColorProp ?? '#007aff';
   const inactiveColor = inactiveColorProp ?? '#d1d5db';
   const knobColor = knobColorProp ?? '#ffffff';
 
-  const handleToggle = (optionValue: string) => {
-    if (selectedValues.includes(optionValue)) {
-      onChange(selectedValues.filter((selected) => selected !== optionValue));
-      return;
-    }
-    onChange([...selectedValues, optionValue]);
-  };
-
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
-      <View style={[styles.optionList, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValues.includes(option.value);
-          const isDisabled = () => option.disabled === true || disabled;
-          return (
-            <ToggleCheckOption
-              accessibilityState={{ checked: isSelected }}
-              activeColor={activeColor}
-              disabled={isDisabled()}
-              hasError={hasError}
-              inactiveColor={inactiveColor}
-              isSelected={isSelected}
-              key={option.key ?? option.value}
-              knobColor={knobColor}
-              knobStyle={knobStyle}
-              label={option.label}
-              onPress={() => {
-                handleToggle(option.value);
-              }}
-              optionLabelStyle={optionLabelStyle}
-              optionRowStyle={optionRowStyle}
-              trackStyle={trackStyle}
-            />
-          );
-        })}
-      </View>
-      <ErrorText {...errorText} />
-    </View>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+      }) => {
+        const selectedValues = Array.isArray(value) ? (value as string[]) : [];
+
+        const handleToggle = (optionValue: string) => {
+          if (selectedValues.includes(optionValue)) {
+            onChange(selectedValues.filter((selected) => selected !== optionValue));
+            return;
+          }
+          onChange([...selectedValues, optionValue]);
+        };
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+            <View style={[styles.optionList, optionListStyle]}>
+              {options.map((option) => {
+                const isSelected = selectedValues.includes(option.value);
+                const isDisabled = () => option.disabled === true || disabled;
+                return (
+                  <ToggleCheckOption
+                    accessibilityState={{ checked: isSelected }}
+                    activeColor={activeColor}
+                    disabled={isDisabled()}
+                    hasError={hasError}
+                    inactiveColor={inactiveColor}
+                    isSelected={isSelected}
+                    key={option.key ?? option.value}
+                    knobColor={knobColor}
+                    knobStyle={knobStyle}
+                    label={option.label}
+                    onPress={() => {
+                      handleToggle(option.value);
+                    }}
+                    optionLabelStyle={optionLabelStyle}
+                    optionRowStyle={optionRowStyle}
+                    trackStyle={trackStyle}
+                  />
+                );
+              })}
+            </View>
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 

--- a/app/components/form/_input.tsx
+++ b/app/components/form/_input.tsx
@@ -1,5 +1,4 @@
-import { useMemo } from 'react';
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { StyleSheet, TextInput, View } from 'react-native';
 
 import ErrorText from './_errorText';
@@ -23,31 +22,39 @@ const Input = <TFieldValues extends FieldValues>({
   style,
   ...textInputProps
 }: TypeInput<TFieldValues>) => {
-  const {
-    field: { onBlur, onChange, value },
-  } = useController({ control, name, rules });
-
-  const inputValue = typeof value === 'string' ? value : '';
   const hasError = errorText?.message != null;
-  const trackAnimatedStyle = useMemo(
-    () => [hasError ? styles.inputError : null, disabled ? styles.inputDisabled : null],
-    [disabled, hasError],
-  );
 
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
-      <TextInput
-        {...textInputProps}
-        editable={!disabled}
-        onBlur={onBlur}
-        onChangeText={onChange}
-        placeholderTextColor={'#9e9e9e'}
-        style={[styles.input, trackAnimatedStyle, style]}
-        value={inputValue}
-      />
-      <ErrorText {...errorText} />
-    </View>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { onBlur, onChange, value },
+      }) => {
+        const inputValue = typeof value === 'string' ? value : '';
+        const trackAnimatedStyle = [
+          hasError ? styles.inputError : null,
+          disabled ? styles.inputDisabled : null,
+        ];
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+            <TextInput
+              {...textInputProps}
+              editable={!disabled}
+              onBlur={onBlur}
+              onChangeText={onChange}
+              placeholderTextColor={'#9e9e9e'}
+              style={[styles.input, trackAnimatedStyle, style]}
+              value={inputValue}
+            />
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 

--- a/app/components/form/_radioBox.tsx
+++ b/app/components/form/_radioBox.tsx
@@ -1,4 +1,4 @@
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
@@ -23,11 +23,6 @@ const RadioBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeRadioBox<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValue = typeof value === 'string' ? value : '';
   const hasError = errorText?.message != null;
 
   const optionLabelStyle = (disabled?: boolean) => {
@@ -43,40 +38,53 @@ const RadioBox = <TFieldValues extends FieldValues>({
   };
 
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
-      <View style={[styles.radioGroup, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValue === option.value;
-          const isDisabled = () => option.disabled === true || disabled;
-          return (
-            <Pressable
-              accessibilityRole='radio'
-              accessibilityState={{ selected: isSelected }}
-              disabled={isDisabled()}
-              key={option.key ?? option.value}
-              onPress={() => {
-                onChange(option.value);
-              }}
-              style={[styles.radioRow, optionRowStyle]}
-            >
-              <View
-                style={[
-                  styles.radioOuter,
-                  isSelected ? styles.radioOuterSelected : null,
-                  hasError ? styles.radioOuterError : null,
-                  optionRadioOuterStyle(isDisabled()),
-                ]}
-              >
-                {isSelected ? <View style={optionRadioInnerStyle(isDisabled())} /> : null}
-              </View>
-              <Text style={optionLabelStyle(isDisabled())}>{option.label}</Text>
-            </Pressable>
-          );
-        })}
-      </View>
-      <ErrorText {...errorText} />
-    </View>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+      }) => {
+        const selectedValue = typeof value === 'string' ? value : '';
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+            <View style={[styles.radioGroup, optionListStyle]}>
+              {options.map((option) => {
+                const isSelected = selectedValue === option.value;
+                const isDisabled = () => option.disabled === true || disabled;
+                return (
+                  <Pressable
+                    accessibilityRole='radio'
+                    accessibilityState={{ selected: isSelected }}
+                    disabled={isDisabled()}
+                    key={option.key ?? option.value}
+                    onPress={() => {
+                      onChange(option.value);
+                    }}
+                    style={[styles.radioRow, optionRowStyle]}
+                  >
+                    <View
+                      style={[
+                        styles.radioOuter,
+                        isSelected ? styles.radioOuterSelected : null,
+                        hasError ? styles.radioOuterError : null,
+                        optionRadioOuterStyle(isDisabled()),
+                      ]}
+                    >
+                      {isSelected ? <View style={optionRadioInnerStyle(isDisabled())} /> : null}
+                    </View>
+                    <Text style={optionLabelStyle(isDisabled())}>{option.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
@@ -108,12 +108,6 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeRadioBoxCustom<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValue = useMemo(() => (typeof value === 'string' ? value : ''), [value]);
-
   const hasError = errorText?.message != null;
 
   const activeColor = activeColorProp ?? '#007aff';
@@ -121,36 +115,49 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
   const knobColor = knobColorProp ?? '#ffffff';
 
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
-      <View style={[styles.optionList, optionListStyle]}>
-        {options.map((option) => {
-          const isSelected = selectedValue === option.value;
-          const isDisabled = () => option.disabled === true || disabled;
-          return (
-            <ToggleRadioOption
-              accessibilityState={{ selected: isSelected }}
-              activeColor={activeColor}
-              disabled={isDisabled()}
-              hasError={hasError}
-              inactiveColor={inactiveColor}
-              isSelected={isSelected}
-              key={option.key ?? option.value}
-              knobColor={knobColor}
-              knobStyle={knobStyle}
-              label={option.label}
-              onPress={() => {
-                onChange(option.value);
-              }}
-              optionLabelStyle={optionLabelStyle}
-              optionRowStyle={optionRowStyle}
-              trackStyle={trackStyle}
-            />
-          );
-        })}
-      </View>
-      <ErrorText {...errorText} />
-    </View>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+      }) => {
+        const selectedValue = typeof value === 'string' ? value : '';
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+            <View style={[styles.optionList, optionListStyle]}>
+              {options.map((option) => {
+                const isSelected = selectedValue === option.value;
+                const isDisabled = () => option.disabled === true || disabled;
+                return (
+                  <ToggleRadioOption
+                    accessibilityState={{ selected: isSelected }}
+                    activeColor={activeColor}
+                    disabled={isDisabled()}
+                    hasError={hasError}
+                    inactiveColor={inactiveColor}
+                    isSelected={isSelected}
+                    key={option.key ?? option.value}
+                    knobColor={knobColor}
+                    knobStyle={knobStyle}
+                    label={option.label}
+                    onPress={() => {
+                      onChange(option.value);
+                    }}
+                    optionLabelStyle={optionLabelStyle}
+                    optionRowStyle={optionRowStyle}
+                    trackStyle={trackStyle}
+                  />
+                );
+              })}
+            </View>
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 

--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useController } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
@@ -32,59 +32,66 @@ const SelectBox = <TFieldValues extends FieldValues>({
   valueTextStyle,
 }: TypeSelectBox<TFieldValues>) => {
   const pickerRef = useRef<RNPickerSelect | null>(null);
-
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValue = ensureString(value);
   const hasError = errorText?.message != null;
-
-  const selectedOption = options.find((option) => option.value === selectedValue);
-  const isPlaceholder = selectedOption == null;
-  const displayLabel = getDisplayLabel(selectedOption, placeholder);
-
-  const triggerStyles = buildTriggerStyles(triggerStyle, hasError, disabled);
-  const triggerTextStyles = buildTriggerTextStyles(
-    isPlaceholder,
-    placeholderTextStyle,
-    valueTextStyle,
-    disabled,
-  );
 
   const openPicker = () => {
     Keyboard.dismiss();
     pickerRef.current?.togglePicker(true);
   };
 
-  const handleValueChange = (selected: string | null) => {
-    onChange(selected ?? '');
-  };
-
   return (
-    <View style={[styles.container, containerStyle]}>
-      <Label {...{ label, rules }} />
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+      }) => {
+        const selectedValue = ensureString(value);
 
-      <Pressable accessibilityRole='button' onPress={openPicker} style={triggerStyles}>
-        <Text style={triggerTextStyles}>{displayLabel}</Text>
-      </Pressable>
+        const selectedOption = options.find((option) => option.value === selectedValue);
+        const isPlaceholder = selectedOption == null;
+        const displayLabel = getDisplayLabel(selectedOption, placeholder);
 
-      <RNPickerSelect
-        disabled={disabled}
-        doneText={doneText}
-        items={options}
-        onValueChange={handleValueChange}
-        placeholder={{ label: placeholder, value: '' }}
-        ref={(ref) => {
-          pickerRef.current = ref;
-        }}
-        style={pickerSelectStyles ?? baseSelectStyles}
-        useNativeAndroidPickerStyle={false}
-        value={toPickerValue(selectedValue)}
-      />
+        const triggerStyles = buildTriggerStyles(triggerStyle, hasError, disabled);
+        const triggerTextStyles = buildTriggerTextStyles(
+          isPlaceholder,
+          placeholderTextStyle,
+          valueTextStyle,
+          disabled,
+        );
 
-      <ErrorText {...errorText} />
-    </View>
+        const handleValueChange = (selected: string | null) => {
+          onChange(selected ?? '');
+        };
+
+        return (
+          <View style={[styles.container, containerStyle]}>
+            <Label {...{ label, rules }} />
+
+            <Pressable accessibilityRole='button' onPress={openPicker} style={triggerStyles}>
+              <Text style={triggerTextStyles}>{displayLabel}</Text>
+            </Pressable>
+
+            <RNPickerSelect
+              disabled={disabled}
+              doneText={doneText}
+              items={options}
+              onValueChange={handleValueChange}
+              placeholder={{ label: placeholder, value: '' }}
+              ref={(ref) => {
+                pickerRef.current = ref;
+              }}
+              style={pickerSelectStyles ?? baseSelectStyles}
+              useNativeAndroidPickerStyle={false}
+              value={toPickerValue(selectedValue)}
+            />
+
+            <ErrorText {...errorText} />
+          </View>
+        );
+      }}
+      rules={rules}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- replace react-hook-form `useController` hooks with the `Controller` component across form inputs
- ensure each form control continues to handle validation state and disabled styling

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e08f5f108324a5f63813e75e4c68)