### PR TITLE
feat: add storybook support for form input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.*
 
 # .husky
 .husky/
+
+# yarn berry artifacts
+.yarn/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/app/types/@storybook/addon-ondevice-actions/index.d.ts
+++ b/app/types/@storybook/addon-ondevice-actions/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@storybook/addon-ondevice-actions';

--- a/app/types/@storybook/addon-ondevice-controls/index.d.ts
+++ b/app/types/@storybook/addon-ondevice-controls/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@storybook/addon-ondevice-controls';

--- a/app/types/@storybook/react-native/index.d.ts
+++ b/app/types/@storybook/react-native/index.d.ts
@@ -1,0 +1,21 @@
+import type { ComponentType, ReactNode } from 'react';
+
+declare module '@storybook/react-native' {
+  export type Meta = {
+    title: string;
+    component?: ComponentType<unknown>;
+    args?: Record<string, unknown>;
+    argTypes?: Record<string, unknown>;
+    decorators?: Array<(Story: () => ReactNode) => ReactNode>;
+    parameters?: Record<string, unknown>;
+  } & Record<string, unknown>;
+
+  export type StoryObj<TArgs = Record<string, unknown>> = {
+    args?: Partial<Record<string, unknown>>;
+    render?: (args: TArgs) => ReactNode;
+    decorators?: Array<(Story: () => ReactNode) => ReactNode>;
+    parameters?: Record<string, unknown>;
+  } & Record<string, unknown>;
+
+  export function getStorybookUI(options?: Record<string, unknown>): ComponentType<unknown>;
+}

--- a/app/types/environment.d.ts
+++ b/app/types/environment.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  const process: {
+    env: {
+      EXPO_PUBLIC_STORYBOOK_ENABLED?: string;
+      [key: string]: string | undefined;
+    };
+  };
+}
+
+export {};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default [
   reactPlugin.configs.flat['jsx-runtime'],
   reactHooks.configs['recommended-latest'],
   {
-    files: ['app/**/*.ts', 'app/**/*.tsx', 'index.ts'],
+    files: ['app/**/*.ts', 'app/**/*.tsx', 'index.ts', 'storybook/**/*.ts', 'storybook/**/*.tsx'],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
 import { registerRootComponent } from 'expo';
 
-import App from './app/App';
+import RootComponent from './storybook/toggle-storybook';
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
-registerRootComponent(App);
+registerRootComponent(RootComponent);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "storybook": "EXPO_PUBLIC_STORYBOOK_ENABLED=true expo start",
     "lint": "eslint . --max-warnings=0 && tsc --noEmit",
     "lint:fix": "eslint --fix --max-warnings=0 ./app",
     "format": "prettier --write ./app",
@@ -37,6 +38,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@storybook/addon-ondevice-actions": "^7.6.20",
+    "@storybook/addon-ondevice-controls": "^7.6.20",
+    "@storybook/react-native": "^7.6.20",
     "@eslint/js": "^9.32.0",
     "@types/react": "~19.1.10",
     "eslint": "^9.32.0",

--- a/storybook/index.ts
+++ b/storybook/index.ts
@@ -1,0 +1,13 @@
+import { getStorybookUI } from '@storybook/react-native';
+
+import type { ComponentType } from 'react';
+
+import './rn-addons';
+import './stories';
+
+const StorybookUIRoot: ComponentType<unknown> = getStorybookUI({
+  asyncStorage: null,
+  shouldDisableKeyboardAvoidingView: true,
+});
+
+export default StorybookUIRoot;

--- a/storybook/rn-addons.ts
+++ b/storybook/rn-addons.ts
@@ -1,0 +1,2 @@
+import '@storybook/addon-ondevice-actions/register';
+import '@storybook/addon-ondevice-controls/register';

--- a/storybook/stories/form/Input.stories.tsx
+++ b/storybook/stories/form/Input.stories.tsx
@@ -1,0 +1,118 @@
+import { useForm } from 'react-hook-form';
+import { StyleSheet, View } from 'react-native';
+
+import Input from '../../../app/components/form/_input';
+
+import type { TypeInput } from '../../../app/lib/types/typeComponents';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import type { FieldError } from 'react-hook-form';
+
+interface StoryFormValues {
+  username: string;
+}
+
+type InputStoryProps = Pick<
+  TypeInput<StoryFormValues>,
+  'label' | 'disabled' | 'placeholder' | 'secureTextEntry'
+> & {
+  errorMessage?: string;
+};
+
+const buildFieldError = (message: string): FieldError => ({
+  message,
+  type: 'manual',
+});
+
+const InputStoryWrapper = ({ errorMessage, ...props }: InputStoryProps) => {
+  const { control } = useForm<StoryFormValues>({
+    defaultValues: { username: '' },
+  });
+
+  const errorProps: FieldError | undefined =
+    errorMessage != null && errorMessage.trim().length > 0
+      ? buildFieldError(errorMessage)
+      : undefined;
+
+  return (
+    <View style={styles.storyContainer}>
+      <Input<StoryFormValues>
+        {...props}
+        control={control}
+        errorText={errorProps}
+        name='username'
+      />
+    </View>
+  );
+};
+
+const meta = {
+  title: 'Components/Form/Input',
+  args: {
+    label: '氏名',
+    placeholder: '山田 太郎',
+  },
+  argTypes: {
+    errorMessage: {
+      control: 'text',
+      description: 'エラー表示に利用する任意のメッセージ',
+    },
+  },
+  decorators: [
+    (StoryComponent) => (
+      <View style={styles.screen}>
+        <StoryComponent />
+      </View>
+    ),
+  ],
+  parameters: {
+    controls: {
+      expanded: true,
+    },
+  },
+} satisfies Meta;
+
+type Story = StoryObj<InputStoryProps>;
+
+const renderStory = (args: InputStoryProps) => <InputStoryWrapper {...args} />;
+
+export const Default: Story = {
+  render: renderStory,
+};
+
+export const Disabled: Story = {
+  render: renderStory,
+  args: {
+    disabled: true,
+    placeholder: '入力は無効です',
+  },
+};
+
+export const WithError: Story = {
+  render: renderStory,
+  args: {
+    errorMessage: '必須項目です',
+  },
+};
+
+export const Password: Story = {
+  render: renderStory,
+  args: {
+    label: 'パスワード',
+    placeholder: '8文字以上',
+    secureTextEntry: true,
+  },
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    backgroundColor: '#f5f5f5',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  storyContainer: {
+    width: '100%',
+  },
+});
+
+export default meta;

--- a/storybook/stories/index.ts
+++ b/storybook/stories/index.ts
@@ -1,0 +1,1 @@
+import './form/Input.stories';

--- a/storybook/toggle-storybook.tsx
+++ b/storybook/toggle-storybook.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+import App from '../app/App';
+
+import type { ComponentType, JSX } from 'react';
+
+const SHOW_STORYBOOK = __DEV__ && process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
+
+const ToggleStorybook = (): JSX.Element => {
+  const [StorybookUI, setStorybookUI] = useState<ComponentType<unknown> | null>(null);
+
+  useEffect(() => {
+    if (!SHOW_STORYBOOK) {
+      return;
+    }
+
+    let isMounted = true;
+
+    import('./index')
+      .then(({ default: StorybookUIRoot }: { default: ComponentType<unknown> }) => {
+        if (isMounted) {
+          setStorybookUI(() => StorybookUIRoot);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load Storybook UI', error);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (SHOW_STORYBOOK && StorybookUI != null) {
+    return <StorybookUI />;
+  }
+
+  return <App />;
+};
+
+export default ToggleStorybook;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["app/**/*.ts", "app/**/*.tsx", "index.ts"]
+  "include": [
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "app/**/*.d.ts",
+    "index.ts",
+    "storybook/**/*.ts",
+    "storybook/**/*.tsx"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,15 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "paths": {
+      "@storybook/react-native": ["./app/types/@storybook/react-native"],
+      "@storybook/addon-ondevice-actions": [
+        "./app/types/@storybook/addon-ondevice-actions"
+      ],
+      "@storybook/addon-ondevice-controls": [
+        "./app/types/@storybook/addon-ondevice-controls"
+      ]
+    },
     "jsx": "react-native",
 
     /* Linting */
@@ -22,6 +31,13 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["app/**/*.ts", "app/**/*.tsx", "index.ts"],
+  "include": [
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "app/**/*.d.ts",
+    "index.ts",
+    "storybook/**/*.ts",
+    "storybook/**/*.tsx"
+  ],
   "exclude": ["node_modules", ".expo", "ios", "android", "eslint.config.js"]
 }


### PR DESCRIPTION
## Summary
- add a Storybook configuration for the Expo app with an environment toggle and on-device addons
- provide type shims for Storybook packages and create stories for the form input component

## Testing
- yarn lint *(fails: requires Storybook packages to be installed in an environment with registry access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914eca868fc8324abf83849f68e8108)