### PR TITLE
Add Storybook configuration and Input component stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,38 @@
+import type { StorybookConfig } from '@storybook/react-webpack5';
+
+const config: StorybookConfig = {
+  stories: ['../app/**/*.stories.@(ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-onboarding',
+  ],
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {},
+  },
+  docs: {
+    autodocs: true,
+  },
+  webpackFinal: async (config) => {
+    if (config.resolve == null) {
+      return config;
+    }
+
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      'react-native$': 'react-native-web',
+      'react-native/Libraries/Animated/NativeAnimatedHelper':
+        'react-native-web/dist/cjs/exports/Animated/NativeAnimatedHelper',
+    };
+
+    config.resolve.extensions = Array.from(
+      new Set([...(config.resolve.extensions ?? []), '.ts', '.tsx']),
+    );
+
+    return config;
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,31 @@
+import type { Preview } from '@storybook/react';
+import { View } from 'react-native';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <View
+        style={{
+          padding: 24,
+          width: '100%',
+          maxWidth: 400,
+          backgroundColor: '#f5f5f5',
+        }}
+      >
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default preview;

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["../app/**/*.stories.ts", "../app/**/*.stories.tsx", "./main.ts", "./preview.ts"],
+  "exclude": []
+}

--- a/app/components/form/_input.stories.tsx
+++ b/app/components/form/_input.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { View } from 'react-native';
+
+import Input from './_input';
+import type { TypeInput } from '../../lib/types/typeComponents';
+
+interface FormValues {
+  sample: string;
+}
+
+type InputBaseProps = Omit<TypeInput<FormValues>, 'control' | 'name' | 'errorText'>;
+
+type InputStoryProps = InputBaseProps & {
+  defaultValue?: string;
+  errorMessage?: string;
+};
+
+const InputStory = ({ defaultValue = '', errorMessage, ...rest }: InputStoryProps) => {
+  const { control, clearErrors, formState, setError, setValue } = useForm<FormValues>({
+    defaultValues: { sample: defaultValue },
+  });
+
+  useEffect(() => {
+    setValue('sample', defaultValue);
+  }, [defaultValue, setValue]);
+
+  useEffect(() => {
+    if (errorMessage) {
+      setError('sample', { type: 'manual', message: errorMessage });
+    } else {
+      clearErrors('sample');
+    }
+  }, [clearErrors, errorMessage, setError]);
+
+  return (
+    <View style={{ width: '100%' }}>
+      <Input<FormValues>
+        {...rest}
+        control={control}
+        name="sample"
+        errorText={errorMessage ? formState.errors.sample : undefined}
+      />
+    </View>
+  );
+};
+
+const meta: Meta<typeof InputStory> = {
+  title: 'Components/Form/Input',
+  component: InputStory,
+  tags: ['autodocs'],
+  args: {
+    label: '氏名',
+    placeholder: '山田太郎',
+  },
+  argTypes: {
+    errorMessage: {
+      control: 'text',
+      description: '表示するエラーメッセージ',
+    },
+    defaultValue: {
+      control: 'text',
+      description: '初期値',
+    },
+    control: { table: { disable: true } },
+    name: { table: { disable: true } },
+    errorText: { table: { disable: true } },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'react-hook-form と連携した入力コンポーネント。Storybook 上では useForm を利用してコントロールしています。',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InputStory>;
+
+export const Default: Story = {};
+
+export const WithInitialValue: Story = {
+  args: {
+    label: 'メールアドレス',
+    placeholder: 'example@example.com',
+    defaultValue: 'sample@example.com',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: '電話番号',
+    placeholder: '090-1234-5678',
+    errorMessage: '必須項目です',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'ユーザー名',
+    defaultValue: 'storybook-user',
+    disabled: true,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint . --max-warnings=0 && tsc --noEmit",
     "lint:fix": "eslint --fix --max-warnings=0 ./app",
     "format": "prettier --write ./app",
-    "fix": "yarn format && yarn lint:fix"
+    "fix": "yarn format && yarn lint:fix",
+    "storybook": "storybook dev -p 6006 --ci",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
@@ -54,7 +56,15 @@
     "react-native-web": "^0.21.0",
     "tsc-files": "^1.1.4",
     "typescript": "~5.8.2",
-    "typescript-eslint": "^8.38.0"
+    "typescript-eslint": "^8.38.0",
+    "@storybook/addon-essentials": "8.4.7",
+    "@storybook/addon-interactions": "8.4.7",
+    "@storybook/addon-links": "8.4.7",
+    "@storybook/addon-onboarding": "8.4.7",
+    "@storybook/cli": "8.4.7",
+    "@storybook/react-webpack5": "8.4.7",
+    "@storybook/testing-library": "0.2.2",
+    "babel-loader": "9.2.1"
   },
   "private": true,
   "lint-staged": {


### PR DESCRIPTION
## Summary
- configure Storybook for the Expo project with webpack aliases for react-native-web
- register Storybook scripts and dev dependencies for running the web Storybook
- add stories that render the form input component through react-hook-form control

## Testing
- yarn lint *(fails: requires updating the lockfile with Storybook dependencies; network-restricted environment prevented fetching packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f5034b3c83249b56b7ab0f2c5449)