### PR TITLE
Use reanimated for custom toggle animations

### DIFF
--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -1,6 +1,14 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useController } from 'react-hook-form';
-import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  interpolate,
+  interpolateColor,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import ErrorText from './_errorText';
 import Label from './_label';
@@ -18,6 +26,8 @@ const KNOB_SIZE = 22;
 const KNOB_MARGIN = (TRACK_HEIGHT - KNOB_SIZE) / 2;
 
 const ERROR_COLOR = '#e53935';
+const DISABLED_COLOR = '#9e9e9e';
+const KNOB_MAX_TRANSLATE = TRACK_WIDTH - KNOB_SIZE - KNOB_MARGIN;
 
 const ToggleCheckOption = ({
   label,
@@ -34,40 +44,30 @@ const ToggleCheckOption = ({
   trackStyle,
   knobStyle,
 }: TypeToggleCheckOption) => {
-  const animation = useRef(new Animated.Value(isSelected ? 1 : 0)).current;
+  const progress: SharedValue<number> = useSharedValue<number>(isSelected ? 1 : 0);
 
   useEffect(() => {
-    Animated.timing(animation, {
-      toValue: isSelected ? 1 : 0,
-      duration: 200,
-      useNativeDriver: false,
-    }).start();
-  }, [animation, isSelected]);
+    progress.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
+  }, [isSelected, progress]);
 
-  const backgroundColor = animation.interpolate({
-    inputRange: [0, 1],
-    outputRange: !disabled ? [inactiveColor, activeColor] : ['#9e9e9e', '#9e9e9e'],
-  });
-
-  const translateX = animation.interpolate({
-    inputRange: [0, 1],
-    outputRange: [KNOB_MARGIN, TRACK_WIDTH - KNOB_SIZE - KNOB_MARGIN],
-  });
-
-  const trackAnimatedStyle = useMemo(
-    () => ({
-      backgroundColor,
-      borderColor: hasError ? ERROR_COLOR : 'transparent',
+  const trackAnimatedStyle = useAnimatedStyle(
+    (): { backgroundColor: string } => ({
+      backgroundColor: disabled
+        ? DISABLED_COLOR
+        : String(interpolateColor(progress.value, [0, 1], [inactiveColor, activeColor])),
     }),
-    [backgroundColor, hasError],
+    [activeColor, disabled, inactiveColor],
   );
 
-  const knobAnimatedStyle = useMemo(
-    () => ({
-      backgroundColor: knobColor,
-      transform: [{ translateX }],
+  const knobAnimatedStyle = useAnimatedStyle(
+    (): { transform: { translateX: number }[] } => ({
+      transform: [
+        {
+          translateX: interpolate(progress.value, [0, 1], [KNOB_MARGIN, KNOB_MAX_TRANSLATE]),
+        },
+      ],
     }),
-    [knobColor, translateX],
+    [],
   );
 
   return (
@@ -78,8 +78,17 @@ const ToggleCheckOption = ({
       onPress={onPress}
       style={[styles.optionRow, optionRowStyle]}
     >
-      <Animated.View style={[styles.track, trackAnimatedStyle, trackStyle]}>
-        <Animated.View style={[styles.knob, knobAnimatedStyle, knobStyle]} />
+      <Animated.View
+        style={[
+          styles.track,
+          hasError ? styles.trackError : styles.trackDefault,
+          trackAnimatedStyle,
+          trackStyle,
+        ]}
+      >
+        <Animated.View
+          style={[styles.knob, { backgroundColor: knobColor }, knobAnimatedStyle, knobStyle]}
+        />
       </Animated.View>
       <Text
         style={[styles.optionLabel, optionLabelStyle, disabled ? styles.optionLabelDisabled : null]}
@@ -181,6 +190,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: KNOB_MARGIN,
     width: TRACK_WIDTH,
+  },
+  trackDefault: {
+    borderColor: 'transparent',
+  },
+  trackError: {
+    borderColor: ERROR_COLOR,
   },
   knob: {
     borderRadius: KNOB_SIZE / 2,

--- a/app/lib/types/declaration/react-native-reanimated.d.ts
+++ b/app/lib/types/declaration/react-native-reanimated.d.ts
@@ -1,0 +1,37 @@
+import type { ComponentType } from 'react';
+import type { ViewProps } from 'react-native';
+
+declare module 'react-native-reanimated' {
+  export type SharedValue<T> = { value: T };
+
+  export const interpolate: (
+    value: number,
+    inputRange: ReadonlyArray<number>,
+    outputRange: ReadonlyArray<number>,
+    extrapolate?: string,
+  ) => number;
+
+  export const interpolateColor: (
+    value: number,
+    inputRange: ReadonlyArray<number>,
+    outputRange: ReadonlyArray<string | number>,
+  ) => string | number;
+
+  export function useSharedValue<T>(initialValue: T): SharedValue<T>;
+
+  export function withTiming<T>(
+    toValue: T,
+    config?: Record<string, unknown>,
+  ): T;
+
+  export function useAnimatedStyle<T extends object>(
+    updater: () => T,
+    deps?: ReadonlyArray<unknown>,
+  ): T;
+
+  const Animated: {
+    View: ComponentType<ViewProps>;
+  };
+
+  export default Animated;
+}

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,9 @@
+/* eslint-disable */
+module.exports = function (api) {
+  api.cache(true);
+
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,9 @@ const reactPlugin = react;
 const reactNativePlugin = reactNative;
 
 export default [
+  {
+    ignores: ['babel.config.*'],
+  },
   js.configs.recommended,
   sonarjs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-hook-form": "^7.66.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-reanimated": "~3.16.1",
     "react-native-pager-view": "6.9.1",
     "react-native-picker-select": "^9.3.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["app/**/*.ts", "app/**/*.tsx", "index.ts"]
+  "include": ["app/**/*.ts", "app/**/*.tsx", "app/**/*.d.ts", "index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-native",
+    "typeRoots": [
+      "./app/types",
+      "./app/lib/types/declaration",
+      "./node_modules/@types"
+    ],
 
     /* Linting */
     "strict": true,
@@ -22,6 +27,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["app/**/*.ts", "app/**/*.tsx", "index.ts"],
+  "include": ["app/**/*.ts", "app/**/*.tsx", "app/**/*.d.ts", "index.ts"],
   "exclude": ["node_modules", ".expo", "ios", "android", "eslint.config.js"]
 }


### PR DESCRIPTION
## Summary
- replace the checkbox and radio toggle implementations to animate with react-native-reanimated for smoother transitions and clearer error states
- add the react-native-reanimated dependency, Babel plugin configuration, and ambient TypeScript declarations needed for Expo and EAS builds
- extend lint and TypeScript configurations to recognise the new build setup while keeping existing checks passing
- relocate the react-native-reanimated ambient declaration into `app/lib/types/declaration` so shared type definitions live under the consolidated lib tree

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175042c53883249bfeb5c63b992bfc)