### PR TITLE
Allow Input component to work without react-hook-form

### DIFF
--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -90,9 +90,9 @@ export type TypeErrorText = Merge<FieldError, (FieldError | undefined)[]>;
  */
 export type TypeInput<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText | FieldError;
   containerStyle?: StyleProp<ViewStyle>;


### PR DESCRIPTION
## Summary
- allow the shared Input component to fall back to local state when no react-hook-form control is supplied
- update the TypeInput typings so control and name are optional and share rendering logic between controlled and uncontrolled modes

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69182b09affc8324897057de180916d0)