### PR TITLE
Allow form components to render without form props

### DIFF
--- a/app/components/form/_checkBox.tsx
+++ b/app/components/form/_checkBox.tsx
@@ -23,19 +23,23 @@ const CheckBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeCheckBox<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
+  const shouldUseController = Boolean(control && name);
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
+  const controllerValue = controller?.field.value;
 
-  const selectedValues = Array.isArray(value) ? (value as string[]) : [];
+  const selectedValues = Array.isArray(controllerValue) ? (controllerValue as string[]) : [];
   const hasError = Boolean(errorText);
 
   const handleToggle = (optionValue: string) => {
-    if (selectedValues.includes(optionValue)) {
-      onChange(selectedValues.filter((selected) => selected !== optionValue));
+    if (!shouldUseController || controller == null) {
       return;
     }
-    onChange([...selectedValues, optionValue]);
+
+    if (selectedValues.includes(optionValue)) {
+      controller.field.onChange(selectedValues.filter((selected) => selected !== optionValue));
+      return;
+    }
+    controller.field.onChange([...selectedValues, optionValue]);
   };
 
   const optionLabelStyle = (disabled?: boolean) => {
@@ -48,7 +52,7 @@ const CheckBox = <TFieldValues extends FieldValues>({
       <View style={[styles.checkBoxGroup, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValues.includes(option.value);
-          const isDisabled = () => option.disabled === true || disabled;
+          const isDisabled = () => option.disabled === true || disabled || !shouldUseController;
           return (
             <Pressable
               accessibilityRole='checkbox'

--- a/app/components/form/_checkBox.tsx
+++ b/app/components/form/_checkBox.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeCheckBox } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
@@ -23,7 +23,7 @@ const CheckBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeCheckBox<TFieldValues>) => {
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
   const selectedValues = getSelectedValues(controller.field.value, isActive);
   const hasError = Boolean(errorText);
 
@@ -41,7 +41,12 @@ const CheckBox = <TFieldValues extends FieldValues>({
               disabled={isDisabled}
               key={option.key ?? option.value}
               onPress={() => {
-                handleToggleOption(option.value, selectedValues, controller.field.onChange, isActive);
+                handleToggleOption(
+                  option.value,
+                  selectedValues,
+                  controller.field.onChange,
+                  isActive,
+                );
               }}
               style={[styles.checkBoxRow, optionRowStyle]}
             >

--- a/app/components/form/_checkBox.tsx
+++ b/app/components/form/_checkBox.tsx
@@ -1,8 +1,8 @@
-import { useController } from 'react-hook-form';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
 import Label from './_label';
+import useOptionalController from './_useOptionalController';
 
 import type { TypeCheckBox } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
@@ -23,28 +23,9 @@ const CheckBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeCheckBox<TFieldValues>) => {
-  const shouldUseController = Boolean(control && name);
-  const controller = shouldUseController ? useController({ control, name, rules }) : null;
-  const controllerValue = controller?.field.value;
-
-  const selectedValues = Array.isArray(controllerValue) ? (controllerValue as string[]) : [];
+  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const selectedValues = getSelectedValues(controller.field.value, isActive);
   const hasError = Boolean(errorText);
-
-  const handleToggle = (optionValue: string) => {
-    if (!shouldUseController || controller == null) {
-      return;
-    }
-
-    if (selectedValues.includes(optionValue)) {
-      controller.field.onChange(selectedValues.filter((selected) => selected !== optionValue));
-      return;
-    }
-    controller.field.onChange([...selectedValues, optionValue]);
-  };
-
-  const optionLabelStyle = (disabled?: boolean) => {
-    return disabled === true ? styles.checkBoxTextDisabled : null;
-  };
 
   return (
     <View style={containerStyle}>
@@ -52,15 +33,15 @@ const CheckBox = <TFieldValues extends FieldValues>({
       <View style={[styles.checkBoxGroup, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValues.includes(option.value);
-          const isDisabled = () => option.disabled === true || disabled || !shouldUseController;
+          const isDisabled = getIsOptionDisabled(option.disabled, disabled, isActive);
           return (
             <Pressable
               accessibilityRole='checkbox'
               accessibilityState={{ checked: isSelected }}
-              disabled={isDisabled()}
+              disabled={isDisabled}
               key={option.key ?? option.value}
               onPress={() => {
-                handleToggle(option.value);
+                handleToggleOption(option.value, selectedValues, controller.field.onChange, isActive);
               }}
               style={[styles.checkBoxRow, optionRowStyle]}
             >
@@ -69,10 +50,10 @@ const CheckBox = <TFieldValues extends FieldValues>({
                   styles.checkBoxBase,
                   isSelected ? styles.checkBoxChecked : null,
                   hasError ? styles.checkBoxError : null,
-                  isDisabled() ? styles.checkBoxDisabled : null,
+                  isDisabled ? styles.checkBoxDisabled : null,
                 ]}
               />
-              <Text style={optionLabelStyle(isDisabled())}>{option.label}</Text>
+              <Text style={getOptionLabelStyle(isDisabled)}>{option.label}</Text>
             </Pressable>
           );
         })}
@@ -80,6 +61,49 @@ const CheckBox = <TFieldValues extends FieldValues>({
       <ErrorText errorText={errorText} />
     </View>
   );
+};
+
+const getSelectedValues = (value: unknown, isActive: boolean): string[] => {
+  if (!isActive || !Array.isArray(value)) {
+    return [];
+  }
+  return value as string[];
+};
+
+const getIsOptionDisabled = (
+  optionDisabled: boolean | undefined,
+  disabled: boolean,
+  isActive: boolean,
+): boolean => {
+  if (!isActive) {
+    return true;
+  }
+
+  return optionDisabled === true || disabled;
+};
+
+const handleToggleOption = (
+  optionValue: string,
+  selectedValues: string[],
+  onChange: (value: string[]) => void,
+  isActive: boolean,
+) => {
+  if (!isActive) {
+    return;
+  }
+
+  if (selectedValues.includes(optionValue)) {
+    onChange(selectedValues.filter((selected) => selected !== optionValue));
+    return;
+  }
+  onChange([...selectedValues, optionValue]);
+};
+
+const getOptionLabelStyle = (disabled: boolean) => {
+  if (!disabled) {
+    return null;
+  }
+  return styles.checkBoxTextDisabled;
 };
 
 const styles = StyleSheet.create({

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -11,7 +11,7 @@ import Animated, {
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeCheckBoxCustom, TypeToggleCheckOption } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
@@ -91,7 +91,13 @@ const ToggleCheckOption = ({
           style={[styles.knob, { backgroundColor: knobColor }, knobAnimatedStyle, knobStyle]}
         />
       </Animated.View>
-      <Text style={[styles.optionLabel, optionLabelStyle, isDisabled ? styles.optionLabelDisabled : null]}>
+      <Text
+        style={[
+          styles.optionLabel,
+          optionLabelStyle,
+          isDisabled ? styles.optionLabelDisabled : null,
+        ]}
+      >
         {label}
       </Text>
     </Pressable>
@@ -116,7 +122,7 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeCheckBoxCustom<TFieldValues>) => {
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
   const controllerValue = controller.field.value;
 
   const selectedValues = useMemo(
@@ -150,7 +156,12 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
               knobStyle={knobStyle}
               label={option.label}
               onPress={() => {
-                handleToggleOption(option.value, selectedValues, controller.field.onChange, isActive);
+                handleToggleOption(
+                  option.value,
+                  selectedValues,
+                  controller.field.onChange,
+                  isActive,
+                );
               }}
               optionLabelStyle={optionLabelStyle}
               optionRowStyle={optionRowStyle}

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -117,11 +117,14 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeCheckBoxCustom<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
+  const shouldUseController = Boolean(control && name);
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
+  const controllerValue = controller?.field.value;
 
-  const selectedValues = useMemo(() => (Array.isArray(value) ? (value as string[]) : []), [value]);
+  const selectedValues = useMemo(
+    () => (Array.isArray(controllerValue) ? (controllerValue as string[]) : []),
+    [controllerValue],
+  );
 
   const hasError = Boolean(errorText);
 
@@ -130,11 +133,15 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   const knobColor = knobColorProp ?? '#ffffff';
 
   const handleToggle = (optionValue: string) => {
-    if (selectedValues.includes(optionValue)) {
-      onChange(selectedValues.filter((selected) => selected !== optionValue));
+    if (!shouldUseController || controller == null) {
       return;
     }
-    onChange([...selectedValues, optionValue]);
+
+    if (selectedValues.includes(optionValue)) {
+      controller.field.onChange(selectedValues.filter((selected) => selected !== optionValue));
+      return;
+    }
+    controller.field.onChange([...selectedValues, optionValue]);
   };
 
   return (
@@ -143,7 +150,7 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
       <View style={[styles.optionList, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValues.includes(option.value);
-          const isDisabled = () => option.disabled === true || disabled;
+          const isDisabled = () => option.disabled === true || disabled || !shouldUseController;
           return (
             <ToggleCheckOption
               accessibilityState={{ checked: isSelected }}

--- a/app/components/form/_input.tsx
+++ b/app/components/form/_input.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, TextInput, View } from 'react-native';
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeInput } from '../../lib/types/typeComponents';
 import type { FieldValues, UseControllerReturn } from 'react-hook-form';
@@ -24,7 +24,7 @@ const Input = <TFieldValues extends FieldValues>({
   style,
   ...textInputProps
 }: TypeInput<TFieldValues>) => {
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
 
   const hasError = Boolean(errorText);
   const trackAnimatedStyle = useMemo(

--- a/app/components/form/_input.tsx
+++ b/app/components/form/_input.tsx
@@ -23,16 +23,24 @@ const Input = <TFieldValues extends FieldValues>({
   style,
   ...textInputProps
 }: TypeInput<TFieldValues>) => {
-  const {
-    field: { onBlur, onChange, value },
-  } = useController({ control, name, rules });
+  const shouldUseController = Boolean(control && name);
 
-  const inputValue = typeof value === 'string' ? value : '';
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
+
+  const inputValue = typeof controller?.field.value === 'string' ? controller.field.value : undefined;
   const hasError = Boolean(errorText);
   const trackAnimatedStyle = useMemo(
     () => [hasError ? styles.inputError : null, disabled ? styles.inputDisabled : null],
     [disabled, hasError],
   );
+
+  const controllerProps = shouldUseController
+    ? {
+        onBlur: controller?.field.onBlur,
+        onChangeText: controller?.field.onChange,
+        value: inputValue ?? '',
+      }
+    : {};
 
   return (
     <View style={containerStyle}>
@@ -40,11 +48,9 @@ const Input = <TFieldValues extends FieldValues>({
       <TextInput
         {...textInputProps}
         editable={!disabled}
-        onBlur={onBlur}
-        onChangeText={onChange}
         placeholderTextColor={'#9e9e9e'}
         style={[styles.input, trackAnimatedStyle, style]}
-        value={inputValue}
+        {...controllerProps}
       />
       <ErrorText errorText={errorText} />
     </View>

--- a/app/components/form/_radioBox.tsx
+++ b/app/components/form/_radioBox.tsx
@@ -23,11 +23,10 @@ const RadioBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeRadioBox<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
+  const shouldUseController = Boolean(control && name);
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
 
-  const selectedValue = typeof value === 'string' ? value : '';
+  const selectedValue = typeof controller?.field.value === 'string' ? controller.field.value : '';
   const hasError = Boolean(errorText);
 
   const optionLabelStyle = (disabled?: boolean) => {
@@ -48,7 +47,7 @@ const RadioBox = <TFieldValues extends FieldValues>({
       <View style={[styles.radioGroup, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValue === option.value;
-          const isDisabled = () => option.disabled === true || disabled;
+          const isDisabled = () => option.disabled === true || disabled || !shouldUseController;
           return (
             <Pressable
               accessibilityRole='radio'
@@ -56,7 +55,10 @@ const RadioBox = <TFieldValues extends FieldValues>({
               disabled={isDisabled()}
               key={option.key ?? option.value}
               onPress={() => {
-                onChange(option.value);
+                if (!shouldUseController || controller == null) {
+                  return;
+                }
+                controller.field.onChange(option.value);
               }}
               style={[styles.radioRow, optionRowStyle]}
             >

--- a/app/components/form/_radioBox.tsx
+++ b/app/components/form/_radioBox.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeRadioBox } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
@@ -23,7 +23,7 @@ const RadioBox = <TFieldValues extends FieldValues>({
   options,
   rules,
 }: TypeRadioBox<TFieldValues>) => {
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
 
   const selectedValue = getSelectedValue(controller.field.value, isActive);
   const hasError = Boolean(errorText);

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -117,11 +117,14 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeRadioBoxCustom<TFieldValues>) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
+  const shouldUseController = Boolean(control && name);
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
+  const controllerValue = controller?.field.value;
 
-  const selectedValue = useMemo(() => (typeof value === 'string' ? value : ''), [value]);
+  const selectedValue = useMemo(
+    () => (typeof controllerValue === 'string' ? controllerValue : ''),
+    [controllerValue],
+  );
 
   const hasError = Boolean(errorText);
 
@@ -135,7 +138,7 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
       <View style={[styles.optionList, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValue === option.value;
-          const isDisabled = () => option.disabled === true || disabled;
+          const isDisabled = () => option.disabled === true || disabled || !shouldUseController;
           return (
             <ToggleRadioOption
               accessibilityState={{ selected: isSelected }}
@@ -149,7 +152,10 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
               knobStyle={knobStyle}
               label={option.label}
               onPress={() => {
-                onChange(option.value);
+                if (!shouldUseController || controller == null) {
+                  return;
+                }
+                controller.field.onChange(option.value);
               }}
               optionLabelStyle={optionLabelStyle}
               optionRowStyle={optionRowStyle}

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -11,7 +11,7 @@ import Animated, {
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeRadioBoxCustom, TypeToggleRadioOption } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
@@ -91,7 +91,13 @@ const ToggleRadioOption = ({
           style={[styles.knob, { backgroundColor: knobColor }, knobAnimatedStyle, knobStyle]}
         />
       </Animated.View>
-      <Text style={[styles.optionLabel, optionLabelStyle, isDisabled ? styles.optionLabelDisabled : null]}>
+      <Text
+        style={[
+          styles.optionLabel,
+          optionLabelStyle,
+          isDisabled ? styles.optionLabelDisabled : null,
+        ]}
+      >
         {label}
       </Text>
     </Pressable>
@@ -116,7 +122,7 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
   trackStyle,
   knobStyle,
 }: TypeRadioBoxCustom<TFieldValues>) => {
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
   const controllerValue = controller.field.value;
 
   const selectedValue = useMemo(

--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -32,24 +32,23 @@ const SelectBox = <TFieldValues extends FieldValues>({
   valueTextStyle,
 }: TypeSelectBox<TFieldValues>) => {
   const pickerRef = useRef<RNPickerSelect | null>(null);
+  const shouldUseController = Boolean(control && name);
+  const controller = shouldUseController ? useController({ control, name, rules }) : null;
 
-  const {
-    field: { value, onChange },
-  } = useController({ control, name, rules });
-
-  const selectedValue = ensureString(value);
+  const selectedValue = ensureString(controller?.field.value);
   const hasError = Boolean(errorText);
+  const isDisabled = disabled || !shouldUseController;
 
   const selectedOption = options.find((option) => option.value === selectedValue);
   const isPlaceholder = selectedOption == null;
   const displayLabel = getDisplayLabel(selectedOption, placeholder);
 
-  const triggerStyles = buildTriggerStyles(triggerStyle, hasError, disabled);
+  const triggerStyles = buildTriggerStyles(triggerStyle, hasError, isDisabled);
   const triggerTextStyles = buildTriggerTextStyles(
     isPlaceholder,
     placeholderTextStyle,
     valueTextStyle,
-    disabled,
+    isDisabled,
   );
 
   const openPicker = () => {
@@ -58,19 +57,22 @@ const SelectBox = <TFieldValues extends FieldValues>({
   };
 
   const handleValueChange = (selected: string | null) => {
-    onChange(selected ?? '');
+    if (!shouldUseController || controller == null) {
+      return;
+    }
+    controller.field.onChange(selected ?? '');
   };
 
   return (
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
 
-      <Pressable accessibilityRole='button' onPress={openPicker} style={triggerStyles}>
+      <Pressable accessibilityRole='button' disabled={isDisabled} onPress={openPicker} style={triggerStyles}>
         <Text style={triggerTextStyles}>{displayLabel}</Text>
       </Pressable>
 
       <RNPickerSelect
-        disabled={disabled}
+        disabled={isDisabled}
         doneText={doneText}
         items={options}
         onValueChange={handleValueChange}

--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -4,7 +4,7 @@ import RNPickerSelect from 'react-native-picker-select';
 
 import ErrorText from './_errorText';
 import Label from './_label';
-import useOptionalController from './_useOptionalController';
+import { useRHFController } from '../../services/reactHookFormHelper';
 
 import type { TypeSelectBox, TypeSelectBoxOption } from '../../lib/types/typeComponents';
 import type { ComponentProps } from 'react';
@@ -32,7 +32,7 @@ const SelectBox = <TFieldValues extends FieldValues>({
   valueTextStyle,
 }: TypeSelectBox<TFieldValues>) => {
   const pickerRef = useRef<RNPickerSelect | null>(null);
-  const { controller, isActive } = useOptionalController({ control, name, rules });
+  const { controller, isActive } = useRHFController({ control, name, rules });
 
   const selectedValue = getSelectedValue(controller.field.value, isActive);
   const hasError = Boolean(errorText);
@@ -55,13 +55,20 @@ const SelectBox = <TFieldValues extends FieldValues>({
     pickerRef.current?.togglePicker(true);
   };
 
-  const handleValueChange = buildValueChangeHandler(isActive ? controller.field.onChange : undefined);
+  const handleValueChange = buildValueChangeHandler(
+    isActive ? controller.field.onChange : undefined,
+  );
 
   return (
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
 
-      <Pressable accessibilityRole='button' disabled={isDisabled} onPress={openPicker} style={triggerStyles}>
+      <Pressable
+        accessibilityRole='button'
+        disabled={isDisabled}
+        onPress={openPicker}
+        style={triggerStyles}
+      >
         <Text style={triggerTextStyles}>{displayLabel}</Text>
       </Pressable>
 

--- a/app/components/form/_useOptionalController.ts
+++ b/app/components/form/_useOptionalController.ts
@@ -1,0 +1,40 @@
+import { useRef } from 'react';
+import { useController, useForm } from 'react-hook-form';
+
+import type {
+  Control,
+  DefaultValues,
+  FieldValues,
+  Path,
+  RegisterOptions,
+  UseControllerReturn,
+} from 'react-hook-form';
+
+const FALLBACK_NAME = '__optional__';
+
+const useOptionalController = <TFieldValues extends FieldValues>(
+  params: {
+    control?: Control<TFieldValues>;
+    name?: Path<TFieldValues>;
+    rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
+  },
+): { controller: UseControllerReturn<TFieldValues>; isActive: boolean } => {
+  const { control: fallbackControl } = useForm<TFieldValues>({
+    defaultValues: {} as DefaultValues<TFieldValues>,
+  });
+  const fallbackNameRef = useRef<Path<TFieldValues>>(
+    FALLBACK_NAME as Path<TFieldValues>,
+  );
+
+  const isActive = Boolean(params.control && params.name);
+
+  const controller = useController<TFieldValues>({
+    control: (isActive ? params.control : fallbackControl) as Control<TFieldValues>,
+    name: (isActive ? params.name : fallbackNameRef.current) as Path<TFieldValues>,
+    rules: params.rules,
+  });
+
+  return { controller, isActive };
+};
+
+export default useOptionalController;

--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -18,9 +18,9 @@ export type TypeBoxOption = {
 
 type TypeToggleCustomBase<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   options: TypeBoxOption[];
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText;
@@ -40,9 +40,9 @@ type TypeToggleCustomBase<TFieldValues extends FieldValues> = {
  */
 export type TypeCheckBox<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   options: TypeBoxOption[];
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText;
@@ -83,9 +83,9 @@ export type TypeErrorText = string | undefined;
  */
 export type TypeInput<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText;
   containerStyle?: StyleProp<ViewStyle>;
@@ -105,9 +105,9 @@ export type TypeLabel<TFieldValues extends FieldValues> = {
  */
 export type TypeRadioBox<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   options: TypeBoxOption[];
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText;
@@ -147,9 +147,9 @@ export type TypeSelectBoxOption = Omit<Item, 'value'> & {
 
 export type TypeSelectBox<TFieldValues extends FieldValues> = {
   label?: string;
-  control: Control<TFieldValues>;
+  control?: Control<TFieldValues>;
   disabled?: boolean;
-  name: Path<TFieldValues>;
+  name?: Path<TFieldValues>;
   options: TypeSelectBoxOption[];
   rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
   errorText?: TypeErrorText;

--- a/app/services/reactHookFormHelper/_useRHFController.ts
+++ b/app/services/reactHookFormHelper/_useRHFController.ts
@@ -12,19 +12,20 @@ import type {
 
 const FALLBACK_NAME = '__optional__';
 
-const useOptionalController = <TFieldValues extends FieldValues>(
-  params: {
-    control?: Control<TFieldValues>;
-    name?: Path<TFieldValues>;
-    rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
-  },
-): { controller: UseControllerReturn<TFieldValues>; isActive: boolean } => {
+/* -----------------------------------------------
+ * react-hook-form
+ * useController 使用のための関数
+ * ----------------------------------------------- */
+
+export const useRHFController = <TFieldValues extends FieldValues>(params: {
+  control?: Control<TFieldValues>;
+  name?: Path<TFieldValues>;
+  rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
+}): { controller: UseControllerReturn<TFieldValues>; isActive: boolean } => {
   const { control: fallbackControl } = useForm<TFieldValues>({
     defaultValues: {} as DefaultValues<TFieldValues>,
   });
-  const fallbackNameRef = useRef<Path<TFieldValues>>(
-    FALLBACK_NAME as Path<TFieldValues>,
-  );
+  const fallbackNameRef = useRef<Path<TFieldValues>>(FALLBACK_NAME as Path<TFieldValues>);
 
   const isActive = Boolean(params.control && params.name);
 
@@ -36,5 +37,3 @@ const useOptionalController = <TFieldValues extends FieldValues>(
 
   return { controller, isActive };
 };
-
-export default useOptionalController;

--- a/app/services/reactHookFormHelper/index.ts
+++ b/app/services/reactHookFormHelper/index.ts
@@ -1,0 +1,1 @@
+export * from './_useRHFController';


### PR DESCRIPTION
## Summary
- allow the shared form components under `app/components/form/` to degrade gracefully when `control` and `name` props are not provided
- make the associated type definitions accept optional `control`/`name` so the components can be used purely for presentation

## Testing
- `yarn lint` *(fails: workspace package missing from lockfile in the provided environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b03db67bc8324957d136492dc7c08)