### PR TITLE
Handle axios errors safely

### DIFF
--- a/app/features/main/home/homeNest/child01/_screen.tsx
+++ b/app/features/main/home/homeNest/child01/_screen.tsx
@@ -17,10 +17,11 @@ const Child01Screen: React.FC = () => {
   const getArticles = async () => {
     setIsDisabled(true);
     try {
-      const result = await getArticleApi();
-      setArticles(result.data as TypeArticle[]);
-    } catch (error) {
-      console.error('Failed to fetch articles', error);
+      const result = await getArticleApi<TypeArticle[]>();
+      setArticles(result.data);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      console.error('Failed to fetch articles', message);
     } finally {
       setIsDisabled(false);
     }

--- a/app/services/apiHelper/_execute.ts
+++ b/app/services/apiHelper/_execute.ts
@@ -57,12 +57,17 @@ export const execute = async <TResponse = unknown, TRequest = unknown>(
 
   try {
     return await axios.request<TResponse>(requestConfig);
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const message = axiosError.response?.data ?? axiosError.message;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data ?? error.message;
 
+      console.error('API request failed', message);
+      throw error;
+    }
+
+    const message = error instanceof Error ? error.message : 'Unknown error';
     console.error('API request failed', message);
-    throw axiosError;
+    throw error instanceof Error ? error : new Error(message);
   }
 };
 
@@ -91,6 +96,5 @@ export const postApi = async <TResponse = unknown, TRequest = unknown>(
   });
 
 // テストゲットAPI（てきとーなやつ）
-export const getArticleApi = () => {
-  return getApi('/wp-json/wp/v2/posts');
-};
+export const getArticleApi = <TResponse = unknown>() =>
+  getApi<TResponse>('/wp-json/wp/v2/posts');


### PR DESCRIPTION
## Summary
- guard axios error handling to avoid unsafe property access
- type article fetch responses explicitly to remove casts

## Testing
- yarn checker *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d1ae98108324b14c39468c3963fa)