### PR TITLE
Fix API helper error handling and typed responses

### DIFF
--- a/app/features/main/home/homeNest/child01/_screen.tsx
+++ b/app/features/main/home/homeNest/child01/_screen.tsx
@@ -17,8 +17,8 @@ const Child01Screen: React.FC = () => {
   const getArticles = async () => {
     setIsDisabled(true);
     try {
-      const result = await getArticleApi();
-      setArticles(result.data as TypeArticle[]);
+      const result = await getArticleApi<TypeArticle[]>();
+      setArticles(result.data);
     } catch (error) {
       console.error('Failed to fetch articles', error);
     } finally {

--- a/app/features/main/home/homeNest/child02/_screen.tsx
+++ b/app/features/main/home/homeNest/child02/_screen.tsx
@@ -40,8 +40,8 @@ const Child02Screen: React.FC = () => {
           'taxCategory03[]': values.taxCategory03,
         };
         // クエリパラムを使用して記事を取得するAPI処理
-        const result = await getCategorizedArticleApi(params);
-        setArticles(result.data as TypeArticle[]);
+        const result = await getCategorizedArticleApi<TypeArticle[]>(params);
+        setArticles(result.data);
       } catch (error) {
         console.error('Failed to fetch articles', error);
         setIsDisabled(false);

--- a/app/services/apiHelper/_execute.ts
+++ b/app/services/apiHelper/_execute.ts
@@ -10,6 +10,34 @@ import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 // デフォルトのベースURL
 const DEFAULT_BASE_URL = 'http://wp.empty-service.com';
 
+// eslint-disable-next-line complexity -- Necessary branches to safely parse axios error payloads
+const buildErrorMessage = (error: AxiosError): string => {
+  const responseData = error.response?.data;
+
+  if (typeof responseData === 'string') {
+    return responseData;
+  }
+
+  if (responseData !== null && typeof responseData === 'object') {
+    const message = (responseData as { message?: unknown }).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+
+  return error.message;
+};
+
+const handleRequestError = (error: unknown): never => {
+  if (axios.isAxiosError(error)) {
+    console.error('API request failed', buildErrorMessage(error));
+    throw error;
+  }
+
+  console.error('API request failed', error);
+  throw new Error('API request failed');
+};
+
 // API通信の実行処理
 export const execute = async <TResponse = unknown, TRequest = unknown>(
   options: TypeOptions<TRequest>,
@@ -34,12 +62,8 @@ export const execute = async <TResponse = unknown, TRequest = unknown>(
 
   try {
     return await axios.request<TResponse>(requestConfig);
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const message = axiosError.response?.data ?? axiosError.message;
-
-    console.error('API request failed', message);
-    throw axiosError;
+  } catch (error: unknown) {
+    return handleRequestError(error);
   }
 };
 
@@ -93,14 +117,14 @@ export const postApi = async <TResponse = unknown, TRequest = unknown>(
  * ----------------------------------------------- */
 
 // 記事を取得するAPI（てきとーなやつ）
-export const getArticleApi = () => {
-  return getApi('/wp-json/wp/v2/posts'); // DEFAULT_BASE_URL を使う例
+export const getArticleApi = <TResponse = unknown>() => {
+  return getApi<TResponse>('/wp-json/wp/v2/posts'); // DEFAULT_BASE_URL を使う例
 };
 
 // クエリパラムを使用して記事を取得するAPI（てきとーなやつ）
-export const getCategorizedArticleApi = (params: TypeParams) => {
+export const getCategorizedArticleApi = <TResponse = unknown>(params: TypeParams) => {
   const options = { baseURL: 'http://search-wp.empty-service.com' };
-  return getApi('/wp-json/wp/v2/org_api', params, options); // DEFAULT_BASE_URL を使わない例
+  return getApi<TResponse>('/wp-json/wp/v2/org_api', params, options); // DEFAULT_BASE_URL を使わない例
 };
 
 /*


### PR DESCRIPTION
## Summary
- add safe Axios error parsing with typed helper in API executor
- type article fetcher helpers and consumers to avoid unsafe data access

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258bc179d88324933c2f1968445250)