### PR TITLE
Add AWS Cognito authentication with Amplify

### DIFF
--- a/app/features/others/auth/_screen.tsx
+++ b/app/features/others/auth/_screen.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { SignInForm, SignUpForm, VerifyForm } from './_component';
 import { Button } from '../../../components/button';
 import { Layout } from '../../../components/layout';
+import { signIn, signOut, signUp, verify } from './_service';
 
 import type { TypeSignInValues, TypeSignUpValues, TypeTabKey, TypeVerifyValues } from './_type';
 
@@ -14,6 +15,8 @@ import type { TypeSignInValues, TypeSignUpValues, TypeTabKey, TypeVerifyValues }
 
 const AuthScreen: React.FC = () => {
   const [tabKey, setTabKey] = React.useState<TypeTabKey>('signIn');
+  const [resultMessage, setResultMessage] = React.useState<string>('');
+  const [errorMessage, setErrorMessage] = React.useState<string>('');
 
   /*
    * tabKey アクティブ判定
@@ -33,8 +36,16 @@ const AuthScreen: React.FC = () => {
   // submit処理
   const onSignInSubmit = React.useCallback(() => {
     void signInForm.handleSubmit((values: TypeSignInValues) => {
-      // eslint-disable-next-line no-console
-      console.log(values);
+      setErrorMessage('');
+      setResultMessage('');
+
+      signIn(values)
+        .then((res) => {
+          setResultMessage(`${res.message} (user: ${res.username})`);
+        })
+        .catch((error: unknown) => {
+          setErrorMessage(error instanceof Error ? error.message : 'Sign in failed.');
+        });
     })();
   }, [signInForm]);
 
@@ -51,8 +62,17 @@ const AuthScreen: React.FC = () => {
   // submit処理
   const onSignUpSubmit = React.useCallback(() => {
     void signUpForm.handleSubmit((values: TypeSignUpValues) => {
-      // eslint-disable-next-line no-console
-      console.log(values);
+      setErrorMessage('');
+      setResultMessage('');
+
+      signUp(values)
+        .then((res) => {
+          setResultMessage(`${res.message} (user: ${res.username})`);
+          setTabKey('verify');
+        })
+        .catch((error: unknown) => {
+          setErrorMessage(error instanceof Error ? error.message : 'Sign up failed.');
+        });
     })();
   }, [signUpForm]);
 
@@ -69,10 +89,31 @@ const AuthScreen: React.FC = () => {
   // submit処理
   const onVerifySubmit = React.useCallback(() => {
     void verifyForm.handleSubmit((values: TypeVerifyValues) => {
-      // eslint-disable-next-line no-console
-      console.log(values);
+      setErrorMessage('');
+      setResultMessage('');
+
+      verify(values)
+        .then((res) => {
+          setResultMessage(res.message);
+        })
+        .catch((error: unknown) => {
+          setErrorMessage(error instanceof Error ? error.message : 'Verification failed.');
+        });
     })();
   }, [verifyForm]);
+
+  const onSignOutPress = React.useCallback(() => {
+    setErrorMessage('');
+    setResultMessage('');
+
+    signOut()
+      .then((res) => {
+        setResultMessage(res.message);
+      })
+      .catch((error: unknown) => {
+        setErrorMessage(error instanceof Error ? error.message : 'Sign out failed.');
+      });
+  }, []);
 
   return (
     <Layout>
@@ -94,6 +135,10 @@ const AuthScreen: React.FC = () => {
         ))}
       </View>
 
+      {/* メッセージ表示 */}
+      {resultMessage !== '' ? <Text style={styles.result}>{resultMessage}</Text> : null}
+      {errorMessage !== '' ? <Text style={styles.error}>{errorMessage}</Text> : null}
+
       {/* Sign In フォーム */}
       <SignInForm form={signInForm} onSubmit={onSignInSubmit} visibled={isActive('signIn')} />
 
@@ -102,6 +147,9 @@ const AuthScreen: React.FC = () => {
 
       {/* Verify フォーム */}
       <VerifyForm form={verifyForm} onSubmit={onVerifySubmit} visibled={isActive('verify')} />
+
+      {/* Sign Out ボタン */}
+      <Button onPress={onSignOutPress} pattern='secondary' title='Sign Out' />
     </Layout>
   );
 };
@@ -112,6 +160,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: 24,
+  },
+  result: {
+    color: '#2d6a4f',
+    marginBottom: 12,
+  },
+  error: {
+    color: '#c1121f',
+    marginBottom: 12,
   },
 });
 

--- a/app/features/others/auth/_screen.tsx
+++ b/app/features/others/auth/_screen.tsx
@@ -3,9 +3,9 @@ import { useForm } from 'react-hook-form';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { SignInForm, SignUpForm, VerifyForm } from './_component';
+import { signIn, signOut, signUp, verify } from './_service';
 import { Button } from '../../../components/button';
 import { Layout } from '../../../components/layout';
-import { signIn, signOut, signUp, verify } from './_service';
 
 import type { TypeSignInValues, TypeSignUpValues, TypeTabKey, TypeVerifyValues } from './_type';
 

--- a/app/features/others/auth/_service.ts
+++ b/app/features/others/auth/_service.ts
@@ -1,0 +1,51 @@
+import {
+  signIn as signInWithCognito,
+  signOut as signOutFromCognito,
+  signUp as signUpWithCognito,
+  verify as verifyWithCognito,
+} from '../../../services/authHelper';
+
+import type { TypeSignInValues, TypeSignUpValues, TypeVerifyValues } from './_type';
+
+/* -----------------------------------------------
+ * Auth 画面用サービス
+ * ----------------------------------------------- */
+
+// Sign Up
+export const signUp = async (values: TypeSignUpValues) => {
+  const response = await signUpWithCognito(values);
+
+  return {
+    message: 'Sign up succeeded. Please check your email for the verification code.',
+    username: response?.user?.getUsername?.() ?? values.email,
+  };
+};
+
+// Verify (Confirm Sign Up)
+export const verify = async (values: TypeVerifyValues) => {
+  await verifyWithCognito(values);
+
+  return {
+    message: 'Verification completed. You can now sign in.',
+  };
+};
+
+// Sign In
+export const signIn = async (values: TypeSignInValues) => {
+  const response = await signInWithCognito(values);
+
+  return {
+    isSignedIn: Boolean(response?.isSignedIn),
+    message: response?.isSignedIn ? 'Signed in successfully.' : 'Additional steps are required to complete sign in.',
+    username: response?.username ?? values.email,
+  };
+};
+
+// Sign Out
+export const signOut = async () => {
+  await signOutFromCognito();
+
+  return {
+    message: 'Signed out successfully.',
+  };
+};

--- a/app/features/others/auth/_service.ts
+++ b/app/features/others/auth/_service.ts
@@ -6,23 +6,39 @@ import {
 } from '../../../services/authHelper';
 
 import type { TypeSignInValues, TypeSignUpValues, TypeVerifyValues } from './_type';
+import type { SignInResult, SignUpResult } from '../../../services/authHelper/types';
 
 /* -----------------------------------------------
  * Auth 画面用サービス
  * ----------------------------------------------- */
 
 // Sign Up
-export const signUp = async (values: TypeSignUpValues) => {
-  const response = await signUpWithCognito(values);
+type SignUpResponse = {
+  message: string;
+  username: string;
+};
+
+type VerifyResponse = {
+  message: string;
+};
+
+type SignInResponse = {
+  isSignedIn: boolean;
+  message: string;
+  username: string;
+};
+
+export const signUp = async (values: TypeSignUpValues): Promise<SignUpResponse> => {
+  const response: SignUpResult = await signUpWithCognito(values);
 
   return {
     message: 'Sign up succeeded. Please check your email for the verification code.',
-    username: response?.user?.getUsername?.() ?? values.email,
+    username: response.username ?? values.email,
   };
 };
 
 // Verify (Confirm Sign Up)
-export const verify = async (values: TypeVerifyValues) => {
+export const verify = async (values: TypeVerifyValues): Promise<VerifyResponse> => {
   await verifyWithCognito(values);
 
   return {
@@ -31,18 +47,24 @@ export const verify = async (values: TypeVerifyValues) => {
 };
 
 // Sign In
-export const signIn = async (values: TypeSignInValues) => {
-  const response = await signInWithCognito(values);
+export const signIn = async (values: TypeSignInValues): Promise<SignInResponse> => {
+  const response: SignInResult = await signInWithCognito(values);
 
   return {
-    isSignedIn: Boolean(response?.isSignedIn),
-    message: response?.isSignedIn ? 'Signed in successfully.' : 'Additional steps are required to complete sign in.',
-    username: response?.username ?? values.email,
+    isSignedIn: Boolean(response.isSignedIn),
+    message: response.isSignedIn === true
+      ? 'Signed in successfully.'
+      : 'Additional steps are required to complete sign in.',
+    username: response.username ?? values.email,
   };
 };
 
 // Sign Out
-export const signOut = async () => {
+type SignOutResponse = {
+  message: string;
+};
+
+export const signOut = async (): Promise<SignOutResponse> => {
   await signOutFromCognito();
 
   return {

--- a/app/features/others/auth/_service.ts
+++ b/app/features/others/auth/_service.ts
@@ -52,7 +52,7 @@ export const signIn = async (values: TypeSignInValues): Promise<SignInResponse> 
 
   return {
     isSignedIn: Boolean(response.isSignedIn),
-    message: response.isSignedIn === true
+    message: response.isSignedIn
       ? 'Signed in successfully.'
       : 'Additional steps are required to complete sign in.',
     username: response.username ?? values.email,

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,26 +1,43 @@
 import { Amplify, Auth } from 'aws-amplify';
 
-import type { TypeSignInValues, TypeSignUpValues, TypeVerifyValues } from '../../features/others/auth/_type';
+import type { SignInResult, SignInValues, SignUpResult, SignUpValues, VerifyValues } from './types';
+import type { ResourcesConfig } from 'aws-amplify';
+
+type AuthClient = {
+  signUp: (input: { username: string; password: string; attributes: { email: string } }) => Promise<SignUpResult>;
+  signIn: (input: { username: string; password: string }) => Promise<SignInResult>;
+  confirmSignUp: (username: string, confirmationCode: string) => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+type AmplifyClient = {
+  configure: (config: ResourcesConfig) => void;
+};
+
+const amplifyClient: AmplifyClient = Amplify as unknown as AmplifyClient;
+const authClient: AuthClient = Auth as unknown as AuthClient;
 
 /* -----------------------------------------------
  * Cognito Auth ヘルパー
  * ----------------------------------------------- */
 
 // Amplify 設定
-Amplify.configure({
+const authConfig: ResourcesConfig = {
   Auth: {
     region: 'ap-northeast-1',
     userPoolId: 'ap-northeast-1_rKjlyQsbS',
     userPoolWebClientId: '40oec5o56lukbe6ch1s9al1qh',
     authenticationFlowType: 'USER_PASSWORD_AUTH',
   },
-});
+};
+
+amplifyClient.configure(authConfig);
 
 /*
  * Sign Up
  */
-export const signUp = async (values: TypeSignUpValues) =>
-  Auth.signUp({
+export const signUp = async (values: SignUpValues): Promise<SignUpResult> => {
+  const response = await authClient.signUp({
     username: values.email,
     password: values.password,
     attributes: {
@@ -28,22 +45,36 @@ export const signUp = async (values: TypeSignUpValues) =>
     },
   });
 
+  const username = response.user?.getUsername?.();
+
+  return { username };
+};
+
 /*
  * Sign In
  */
-export const signIn = async (values: TypeSignInValues) =>
-  Auth.signIn({
+export const signIn = async (values: SignInValues): Promise<SignInResult> => {
+  const response = await authClient.signIn({
     username: values.email,
     password: values.password,
   });
 
+  const username = response.username;
+  const isSignedIn = response.isSignedIn;
+
+  return { isSignedIn, username };
+};
+
 /*
  * Verify（確認コード検証）
  */
-export const verify = async (values: TypeVerifyValues) =>
-  Auth.confirmSignUp(values.email, values.verificationCode);
+export const verify = async (values: VerifyValues): Promise<void> => {
+  await authClient.confirmSignUp(values.email, values.verificationCode);
+};
 
 /*
  * Sign Out
  */
-export const signOut = async () => Auth.signOut();
+export const signOut = async (): Promise<void> => {
+  await authClient.signOut();
+};

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,25 +1,14 @@
-import { Amplify, Auth } from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
+import { signIn as cognitoSignIn, signOut as cognitoSignOut, signUp as cognitoSignUp, confirmSignUp } from 'aws-amplify/auth';
 
 import type { SignInResult, SignInValues, SignUpResult, SignUpValues, VerifyValues } from './types';
 import type { ResourcesConfig } from 'aws-amplify';
-
-type AuthClient = {
-  signUp: (input: {
-    username: string;
-    password: string;
-    options: { userAttributes: { email: string } };
-  }) => Promise<SignUpResult>;
-  signIn: (input: { username: string; password: string }) => Promise<SignInResult>;
-  confirmSignUp: (username: string, confirmationCode: string) => Promise<void>;
-  signOut: () => Promise<void>;
-};
 
 type AmplifyClient = {
   configure: (config: ResourcesConfig) => void;
 };
 
 const amplifyClient: AmplifyClient = Amplify as unknown as AmplifyClient;
-const authClient: AuthClient = Auth as unknown as AuthClient;
 
 /* -----------------------------------------------
  * Cognito Auth ヘルパー
@@ -43,7 +32,7 @@ amplifyClient.configure(authConfig);
  * Sign Up
  */
 export const signUp = async (values: SignUpValues): Promise<SignUpResult> => {
-  const response = await authClient.signUp({
+  const response = await cognitoSignUp({
     username: values.email,
     password: values.password,
     options: {
@@ -62,7 +51,7 @@ export const signUp = async (values: SignUpValues): Promise<SignUpResult> => {
  * Sign In
  */
 export const signIn = async (values: SignInValues): Promise<SignInResult> => {
-  const response = await authClient.signIn({
+  const response = await cognitoSignIn({
     username: values.email,
     password: values.password,
   });
@@ -76,12 +65,12 @@ export const signIn = async (values: SignInValues): Promise<SignInResult> => {
  * Verify（確認コード検証）
  */
 export const verify = async (values: VerifyValues): Promise<void> => {
-  await authClient.confirmSignUp(values.email, values.verificationCode);
+  await confirmSignUp({ username: values.email, confirmationCode: values.verificationCode });
 };
 
 /*
  * Sign Out
  */
 export const signOut = async (): Promise<void> => {
-  await authClient.signOut();
+  await cognitoSignOut();
 };

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,0 +1,49 @@
+import { Amplify, Auth } from 'aws-amplify';
+
+import type { TypeSignInValues, TypeSignUpValues, TypeVerifyValues } from '../../features/others/auth/_type';
+
+/* -----------------------------------------------
+ * Cognito Auth ヘルパー
+ * ----------------------------------------------- */
+
+// Amplify 設定
+Amplify.configure({
+  Auth: {
+    region: 'ap-northeast-1',
+    userPoolId: 'ap-northeast-1_rKjlyQsbS',
+    userPoolWebClientId: '40oec5o56lukbe6ch1s9al1qh',
+    authenticationFlowType: 'USER_PASSWORD_AUTH',
+  },
+});
+
+/*
+ * Sign Up
+ */
+export const signUp = async (values: TypeSignUpValues) =>
+  Auth.signUp({
+    username: values.email,
+    password: values.password,
+    attributes: {
+      email: values.email,
+    },
+  });
+
+/*
+ * Sign In
+ */
+export const signIn = async (values: TypeSignInValues) =>
+  Auth.signIn({
+    username: values.email,
+    password: values.password,
+  });
+
+/*
+ * Verify（確認コード検証）
+ */
+export const verify = async (values: TypeVerifyValues) =>
+  Auth.confirmSignUp(values.email, values.verificationCode);
+
+/*
+ * Sign Out
+ */
+export const signOut = async () => Auth.signOut();

--- a/app/services/authHelper/types.ts
+++ b/app/services/authHelper/types.ts
@@ -1,0 +1,26 @@
+export type SignInValues = {
+  email: string;
+  password: string;
+};
+
+export type SignUpValues = {
+  email: string;
+  password: string;
+};
+
+export type VerifyValues = {
+  email: string;
+  verificationCode: string;
+};
+
+export type SignUpResult = {
+  user?: {
+    getUsername?: () => string;
+  };
+  username?: string;
+};
+
+export type SignInResult = {
+  isSignedIn?: boolean;
+  username?: string;
+};

--- a/app/services/authHelper/types.ts
+++ b/app/services/authHelper/types.ts
@@ -14,13 +14,25 @@ export type VerifyValues = {
 };
 
 export type SignUpResult = {
-  user?: {
-    getUsername?: () => string;
+  isSignUpComplete?: boolean;
+  nextStep?: {
+    signUpStep?: string;
+    codeDeliveryDetails?: {
+      attributeName?: string;
+      deliveryMedium?: string;
+      destination?: string;
+    };
   };
+  userId?: string;
   username?: string;
 };
 
 export type SignInResult = {
-  isSignedIn?: boolean;
+  isSignedIn: boolean;
+  nextStep?: {
+    signInStep?: string;
+    additionalInfo?: Record<string, unknown>;
+  };
+  userId?: string;
   username?: string;
 };

--- a/app/types/aws-amplify.d.ts
+++ b/app/types/aws-amplify.d.ts
@@ -19,6 +19,10 @@ declare module 'aws-amplify' {
     configure: (config: ResourcesConfig) => void;
   };
 
+  export const Amplify: AmplifyClient;
+}
+
+declare module 'aws-amplify/auth' {
   export interface SignUpResult {
     isSignUpComplete?: boolean;
     nextStep?: {
@@ -43,15 +47,21 @@ declare module 'aws-amplify' {
     username?: string;
   }
 
-  export const Amplify: AmplifyClient;
-  export const Auth: {
-    signUp: (input: {
-      username: string;
-      password: string;
-      options: { userAttributes: { email: string } };
-    }) => Promise<SignUpResult>;
-    signIn: (input: { username: string; password: string }) => Promise<SignInResult>;
-    confirmSignUp: (username: string, confirmationCode: string) => Promise<void>;
-    signOut: () => Promise<void>;
+  export type SignUpInput = {
+    username: string;
+    password: string;
+    options: { userAttributes: { email: string } };
   };
+
+  export type SignInInput = { username: string; password: string };
+
+  export type ConfirmSignUpInput = {
+    username: string;
+    confirmationCode: string;
+  };
+
+  export const signUp: (input: SignUpInput) => Promise<SignUpResult>;
+  export const signIn: (input: SignInInput) => Promise<SignInResult>;
+  export const confirmSignUp: (input: ConfirmSignUpInput) => Promise<void>;
+  export const signOut: () => Promise<void>;
 }

--- a/app/types/aws-amplify.d.ts
+++ b/app/types/aws-amplify.d.ts
@@ -1,0 +1,36 @@
+declare module 'aws-amplify' {
+  export interface ResourcesConfig {
+    Auth?: {
+      region?: string;
+      userPoolId?: string;
+      userPoolWebClientId?: string;
+      authenticationFlowType?: string;
+    };
+  }
+
+  export type AmplifyClient = {
+    configure: (config: ResourcesConfig) => void;
+  };
+
+  export interface AuthUser {
+    getUsername?: () => string;
+  }
+
+  export interface SignUpResult {
+    user?: AuthUser;
+    username?: string;
+  }
+
+  export interface SignInResult {
+    isSignedIn?: boolean;
+    username?: string;
+  }
+
+  export const Amplify: AmplifyClient;
+  export const Auth: {
+    signUp: (input: { username: string; password: string; attributes?: { email?: string } }) => Promise<SignUpResult>;
+    signIn: (input: { username: string; password: string }) => Promise<SignInResult>;
+    confirmSignUp: (username: string, confirmationCode: string) => Promise<void>;
+    signOut: () => Promise<void>;
+  };
+}

--- a/app/types/aws-amplify.d.ts
+++ b/app/types/aws-amplify.d.ts
@@ -1,10 +1,17 @@
 declare module 'aws-amplify' {
   export interface ResourcesConfig {
     Auth?: {
-      region?: string;
-      userPoolId?: string;
-      userPoolWebClientId?: string;
-      authenticationFlowType?: string;
+      Cognito?: {
+        region: string;
+        userPoolId: string;
+        userPoolClientId: string;
+        loginWith?: {
+          email?: boolean;
+          phone?: boolean;
+          username?: boolean;
+          preferredUsername?: boolean;
+        };
+      };
     };
   }
 
@@ -12,23 +19,37 @@ declare module 'aws-amplify' {
     configure: (config: ResourcesConfig) => void;
   };
 
-  export interface AuthUser {
-    getUsername?: () => string;
-  }
-
   export interface SignUpResult {
-    user?: AuthUser;
+    isSignUpComplete?: boolean;
+    nextStep?: {
+      signUpStep?: string;
+      codeDeliveryDetails?: {
+        attributeName?: string;
+        deliveryMedium?: string;
+        destination?: string;
+      };
+    };
+    userId?: string;
     username?: string;
   }
 
   export interface SignInResult {
-    isSignedIn?: boolean;
+    isSignedIn: boolean;
+    nextStep?: {
+      signInStep?: string;
+      additionalInfo?: Record<string, unknown>;
+    };
+    userId?: string;
     username?: string;
   }
 
   export const Amplify: AmplifyClient;
   export const Auth: {
-    signUp: (input: { username: string; password: string; attributes?: { email?: string } }) => Promise<SignUpResult>;
+    signUp: (input: {
+      username: string;
+      password: string;
+      options: { userAttributes: { email: string } };
+    }) => Promise<SignUpResult>;
     signIn: (input: { username: string; password: string }) => Promise<SignInResult>;
     confirmSignUp: (username: string, confirmationCode: string) => Promise<void>;
     signOut: () => Promise<void>;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-dev-client": "~6.0.17",
     "expo-linking": "~8.0.8",
     "expo-status-bar": "~3.0.8",
+    "aws-amplify": "^6.7.2",
     "react": "19.1.0",
     "react-hook-form": "^7.66.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
## Summary
- configure AWS Amplify Auth with the provided Cognito user pool settings
- add auth services that wrap Cognito sign-up, verification, sign-in, and sign-out flows with user-friendly responses
- connect the auth screen forms to Cognito actions and surface success or error messages with a sign-out control

## Testing
- Not run (aws-amplify installation blocked by registry access restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69285e8a16e08324a2b61fcbc181cadc)