### PR TITLE
Configure Amplify for React Native

### DIFF
--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -1,11 +1,12 @@
-import { getAmplifyConfig } from '@aws-amplify/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Amplify } from 'aws-amplify';
+import { Platform } from 'react-native';
 
 import type { TypeAmplifyClient, TypeAuthConfig } from '../types/typeService';
 
 const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
 
-const authConfig: TypeAuthConfig = {
+const baseAuthConfig: TypeAuthConfig = {
   Auth: {
     Cognito: {
       userPoolId: 'ap-northeast-1_ukr54toDk',
@@ -20,7 +21,17 @@ let isConfigured = false;
 export const configureAmplify = (): void => {
   if (isConfigured) return;
 
-  const nativeConfig = getAmplifyConfig();
-  amplifyClient.configure({ ...nativeConfig, ...authConfig });
+  const nativeStorageConfig: TypeAuthConfig =
+    Platform.OS === 'web'
+      ? {}
+      : {
+          Auth: {
+            ...baseAuthConfig.Auth,
+            // Use AsyncStorage for token persistence on native platforms
+            storage: AsyncStorage,
+          },
+        };
+
+  amplifyClient.configure({ ...baseAuthConfig, ...nativeStorageConfig });
   isConfigured = true;
 };

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -12,34 +12,29 @@ const baseAuthConfig: TypeAuthConfig = {
       userPoolId: 'ap-northeast-1_ukr54toDk',
       userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
       loginWith: { email: true },
+      region: 'ap-northeast-1',
     },
   },
 };
 
-class AmplifyAsyncStorageAdapter {
+const createStorageAdapter = () => Object.create(AmplifyAsyncStoragePrototype);
+
+const AmplifyAsyncStoragePrototype = {
   async getItem(key: string) {
     return AsyncStorage.getItem(key);
-  }
+  },
 
   async setItem(key: string, value: string) {
     await AsyncStorage.setItem(key, value);
-  }
+  },
 
   async removeItem(key: string) {
     await AsyncStorage.removeItem(key);
-  }
+  },
 
   async clear() {
     await AsyncStorage.clear();
-  }
-}
-
-const createFrozenStorageAdapter = () => {
-  // Keep the instance mutability minimal (no own enumerable props) so Amplify's deepFreeze
-  // recursion doesn't trip over strict-mode function properties like `caller`/`arguments`.
-  const adapter = new AmplifyAsyncStorageAdapter();
-  Object.freeze(Object.getPrototypeOf(adapter));
-  return Object.freeze(adapter);
+  },
 };
 
 let isConfigured = false;
@@ -54,7 +49,7 @@ export const configureAmplify = (): void => {
           Auth: {
             ...baseAuthConfig.Auth,
             // Use AsyncStorage for token persistence on native platforms
-            storage: createFrozenStorageAdapter(),
+            storage: createStorageAdapter(),
           },
         };
 

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -1,4 +1,4 @@
-import { getAmplifyConfig } from '@aws-amplify/react-native';
+import { getAmplifyConfig } from 'aws-amplify/react-native';
 import { Amplify } from 'aws-amplify';
 
 import type { TypeAmplifyClient, TypeAuthConfig } from '../types/typeService';

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -17,9 +17,7 @@ const baseAuthConfig: TypeAuthConfig = {
   },
 };
 
-const createStorageAdapter = () => Object.create(AmplifyAsyncStoragePrototype);
-
-const AmplifyAsyncStoragePrototype = {
+const createStorageAdapter = () => ({
   async getItem(key: string) {
     return AsyncStorage.getItem(key);
   },
@@ -35,7 +33,7 @@ const AmplifyAsyncStoragePrototype = {
   async clear() {
     await AsyncStorage.clear();
   },
-};
+});
 
 let isConfigured = false;
 

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -17,41 +17,23 @@ const baseAuthConfig: TypeAuthConfig = {
   },
 };
 
-const createStorageAdapter = () =>
-  Object.freeze({
-    async getItem(key: string) {
-      return AsyncStorage.getItem(key);
-    },
-
-    async setItem(key: string, value: string) {
-      await AsyncStorage.setItem(key, value);
-    },
-
-    async removeItem(key: string) {
-      await AsyncStorage.removeItem(key);
-    },
-
-    async clear() {
-      await AsyncStorage.clear();
-    },
-  });
-
 let isConfigured = false;
 
 export const configureAmplify = (): void => {
   if (isConfigured) return;
 
-  const nativeStorageConfig: TypeAuthConfig =
+  const nativeStorageConfig: TypeAuthConfig['Auth'] =
     Platform.OS === 'web'
-      ? {}
+      ? baseAuthConfig.Auth
       : {
-          Auth: {
-            ...baseAuthConfig.Auth,
-            // Use AsyncStorage for token persistence on native platforms
-            storage: createStorageAdapter(),
-          },
+          ...baseAuthConfig.Auth,
+          // Use AsyncStorage directly to align with Amplify's native defaults
+          storage: AsyncStorage,
         };
 
-  amplifyClient.configure({ ...baseAuthConfig, ...nativeStorageConfig });
+  amplifyClient.configure({
+    ...baseAuthConfig,
+    Auth: nativeStorageConfig,
+  });
   isConfigured = true;
 };

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -16,6 +16,31 @@ const baseAuthConfig: TypeAuthConfig = {
   },
 };
 
+const createFrozenStorageAdapter = () => {
+  const adapter = {
+    async getItem(key: string) {
+      return AsyncStorage.getItem(key);
+    },
+    async setItem(key: string, value: string) {
+      await AsyncStorage.setItem(key, value);
+    },
+    async removeItem(key: string) {
+      await AsyncStorage.removeItem(key);
+    },
+    async clear() {
+      await AsyncStorage.clear();
+    },
+  } as const;
+
+  Object.values(adapter).forEach((value) => {
+    if (typeof value === 'function') {
+      Object.freeze(value);
+    }
+  });
+
+  return Object.freeze(adapter);
+};
+
 let isConfigured = false;
 
 export const configureAmplify = (): void => {
@@ -28,7 +53,7 @@ export const configureAmplify = (): void => {
           Auth: {
             ...baseAuthConfig.Auth,
             // Use AsyncStorage for token persistence on native platforms
-            storage: AsyncStorage,
+            storage: createFrozenStorageAdapter(),
           },
         };
 

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -1,4 +1,4 @@
-import { getAmplifyConfig } from 'aws-amplify/react-native';
+import { getAmplifyConfig } from '@aws-amplify/react-native';
 import { Amplify } from 'aws-amplify';
 
 import type { TypeAmplifyClient, TypeAuthConfig } from '../types/typeService';

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -17,23 +17,24 @@ const baseAuthConfig: TypeAuthConfig = {
   },
 };
 
-const createStorageAdapter = () => ({
-  async getItem(key: string) {
-    return AsyncStorage.getItem(key);
-  },
+const createStorageAdapter = () =>
+  Object.freeze({
+    async getItem(key: string) {
+      return AsyncStorage.getItem(key);
+    },
 
-  async setItem(key: string, value: string) {
-    await AsyncStorage.setItem(key, value);
-  },
+    async setItem(key: string, value: string) {
+      await AsyncStorage.setItem(key, value);
+    },
 
-  async removeItem(key: string) {
-    await AsyncStorage.removeItem(key);
-  },
+    async removeItem(key: string) {
+      await AsyncStorage.removeItem(key);
+    },
 
-  async clear() {
-    await AsyncStorage.clear();
-  },
-});
+    async clear() {
+      await AsyncStorage.clear();
+    },
+  });
 
 let isConfigured = false;
 

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -16,28 +16,29 @@ const baseAuthConfig: TypeAuthConfig = {
   },
 };
 
+class AmplifyAsyncStorageAdapter {
+  async getItem(key: string) {
+    return AsyncStorage.getItem(key);
+  }
+
+  async setItem(key: string, value: string) {
+    await AsyncStorage.setItem(key, value);
+  }
+
+  async removeItem(key: string) {
+    await AsyncStorage.removeItem(key);
+  }
+
+  async clear() {
+    await AsyncStorage.clear();
+  }
+}
+
 const createFrozenStorageAdapter = () => {
-  const adapter = {
-    async getItem(key: string) {
-      return AsyncStorage.getItem(key);
-    },
-    async setItem(key: string, value: string) {
-      await AsyncStorage.setItem(key, value);
-    },
-    async removeItem(key: string) {
-      await AsyncStorage.removeItem(key);
-    },
-    async clear() {
-      await AsyncStorage.clear();
-    },
-  } as const;
-
-  Object.values(adapter).forEach((value) => {
-    if (typeof value === 'function') {
-      Object.freeze(value);
-    }
-  });
-
+  // Keep the instance mutability minimal (no own enumerable props) so Amplify's deepFreeze
+  // recursion doesn't trip over strict-mode function properties like `caller`/`arguments`.
+  const adapter = new AmplifyAsyncStorageAdapter();
+  Object.freeze(Object.getPrototypeOf(adapter));
   return Object.freeze(adapter);
 };
 

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -1,0 +1,25 @@
+import { getAmplifyReactNativeConfig } from '@aws-amplify/react-native';
+import { Amplify } from 'aws-amplify';
+
+import type { TypeAmplifyClient, TypeAuthConfig } from '../types/typeService';
+
+const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
+
+const authConfig: TypeAuthConfig = {
+  Auth: {
+    Cognito: {
+      userPoolId: 'ap-northeast-1_ukr54toDk',
+      userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
+      loginWith: { email: true },
+    },
+  },
+};
+
+let isConfigured = false;
+
+export const configureAmplify = (): void => {
+  if (isConfigured) return;
+
+  amplifyClient.configure(authConfig, getAmplifyReactNativeConfig());
+  isConfigured = true;
+};

--- a/app/lib/amplify/configureAmplify.ts
+++ b/app/lib/amplify/configureAmplify.ts
@@ -1,4 +1,4 @@
-import { getAmplifyReactNativeConfig } from '@aws-amplify/react-native';
+import { getAmplifyConfig } from '@aws-amplify/react-native';
 import { Amplify } from 'aws-amplify';
 
 import type { TypeAmplifyClient, TypeAuthConfig } from '../types/typeService';
@@ -20,6 +20,7 @@ let isConfigured = false;
 export const configureAmplify = (): void => {
   if (isConfigured) return;
 
-  amplifyClient.configure(authConfig, getAmplifyReactNativeConfig());
+  const nativeConfig = getAmplifyConfig();
+  amplifyClient.configure({ ...nativeConfig, ...authConfig });
   isConfigured = true;
 };

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -3,6 +3,7 @@ export type TypeAuthConfig = {
     Cognito?: {
       userPoolId: string;
       userPoolClientId: string;
+      region?: string;
       loginWith?: {
         email?: boolean;
         phone?: boolean;

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -10,6 +10,7 @@ export type TypeAuthConfig = {
         preferredUsername?: boolean;
       };
     };
+    storage?: unknown;
   };
 };
 

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -14,7 +14,7 @@ export type TypeAuthConfig = {
 };
 
 export type TypeAmplifyClient = {
-  configure: (config: TypeAuthConfig, options?: Record<string, unknown>) => void;
+  configure: (config: Record<string, unknown>) => void;
 };
 
 export type TypeSignInValues = {

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -14,7 +14,7 @@ export type TypeAuthConfig = {
 };
 
 export type TypeAmplifyClient = {
-  configure: (config: TypeAuthConfig) => void;
+  configure: (config: TypeAuthConfig, options?: Record<string, unknown>) => void;
 };
 
 export type TypeSignInValues = {

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,4 +1,3 @@
-import { Amplify } from 'aws-amplify';
 import {
   signIn as cognitoSignIn,
   signOut as cognitoSignOut,
@@ -7,14 +6,13 @@ import {
 } from 'aws-amplify/auth';
 
 import type {
-  TypeAmplifyClient,
-  TypeAuthConfig,
   TypeSignInResult,
   TypeSignInValues,
   TypeSignUpResult,
   TypeSignUpValues,
   TypeVerifyValues,
 } from '../../lib/types/typeService';
+import { configureAmplify } from '../../lib/amplify/configureAmplify';
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -29,22 +27,7 @@ const isSignUpResponse = (value: unknown): value is TypeSignUpResult =>
  * Cognito Auth ヘルパー
  * ----------------------------------------------- */
 
-/*
- * Amplify 設定
- */
-const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
-
-const authConfig: TypeAuthConfig = {
-  Auth: {
-    Cognito: {
-      userPoolId: 'ap-northeast-1_ukr54toDk',
-      userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
-      loginWith: { email: true },
-    },
-  },
-};
-
-amplifyClient.configure(authConfig);
+configureAmplify();
 
 /*
  * Sign In 処理

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,10 @@ import 'react-native-url-polyfill/auto';
 import { registerRootComponent } from 'expo';
 import { Platform } from 'react-native';
 
+import { configureAmplify } from './app/lib/amplify/configureAmplify';
 import App from './app/App';
+
+configureAmplify();
 
 if (Platform.OS !== 'web') {
   // Amplify needs native random values polyfilled on iOS/Android

--- a/index.ts
+++ b/index.ts
@@ -1,19 +1,11 @@
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
 import { registerRootComponent } from 'expo';
-import { Platform } from 'react-native';
 
 import { configureAmplify } from './app/lib/amplify/configureAmplify';
 import App from './app/App';
 
 configureAmplify();
-
-if (Platform.OS !== 'web') {
-  // Amplify needs native random values polyfilled on iOS/Android
-  void import('@aws-amplify/react-native').then(({ loadGetRandomValues }) => {
-    loadGetRandomValues();
-  });
-}
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,


### PR DESCRIPTION
## Summary
- add a shared Amplify configurator that uses the React Native storage helpers
- initialize Amplify at app startup and reuse the same configuration inside the auth helper
- update auth helper types to accept additional configure options

## Testing
- yarn lint *(fails: workspace package missing from lockfile; install not run in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929972095108324a0cd21579beb602b)