### PR TITLE
Fix Amplify sign-in support for Expo native

### DIFF
--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -3,6 +3,7 @@ export type TypeAuthConfig = {
     Cognito?: {
       userPoolId: string;
       userPoolClientId: string;
+      region?: string;
       loginWith?: {
         email?: boolean;
         phone?: boolean;

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -18,7 +18,7 @@ export type TypeAuthStorage = {
   getItem: (key: string) => Promise<string | null> | string | null;
   setItem: (key: string, value: string) => Promise<void> | void;
   removeItem: (key: string) => Promise<void> | void;
-};
+} & Record<string, unknown>;
 
 export type TypeAmplifyClient = {
   configure: (config: TypeAuthConfig) => void;

--- a/app/lib/types/typeService/_authHelper.ts
+++ b/app/lib/types/typeService/_authHelper.ts
@@ -10,7 +10,14 @@ export type TypeAuthConfig = {
         preferredUsername?: boolean;
       };
     };
+    storage?: TypeAuthStorage;
   };
+};
+
+export type TypeAuthStorage = {
+  getItem: (key: string) => Promise<string | null> | string | null;
+  setItem: (key: string, value: string) => Promise<void> | void;
+  removeItem: (key: string) => Promise<void> | void;
 };
 
 export type TypeAmplifyClient = {

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,3 +1,5 @@
+import '@aws-amplify/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Amplify } from 'aws-amplify';
 import {
   signIn as cognitoSignIn,
@@ -41,6 +43,7 @@ const authConfig: TypeAuthConfig = {
       userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
       loginWith: { email: true },
     },
+    storage: AsyncStorage,
   },
 };
 

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -37,11 +37,7 @@ const isSignUpResponse = (value: unknown): value is TypeSignUpResult =>
  */
 const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
 
-const storage: TypeAuthStorage = {
-  getItem: (key) => AsyncStorage.getItem(key),
-  setItem: (key, value) => AsyncStorage.setItem(key, value),
-  removeItem: (key) => AsyncStorage.removeItem(key),
-};
+const storage: TypeAuthStorage = AsyncStorage;
 
 const authConfig: TypeAuthConfig = {
   Auth: {

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -11,6 +11,7 @@ import {
 import type {
   TypeAmplifyClient,
   TypeAuthConfig,
+  TypeAuthStorage,
   TypeSignInResult,
   TypeSignInValues,
   TypeSignUpResult,
@@ -36,6 +37,12 @@ const isSignUpResponse = (value: unknown): value is TypeSignUpResult =>
  */
 const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
 
+const storage: TypeAuthStorage = {
+  getItem: (key) => AsyncStorage.getItem(key),
+  setItem: (key, value) => AsyncStorage.setItem(key, value),
+  removeItem: (key) => AsyncStorage.removeItem(key),
+};
+
 const authConfig: TypeAuthConfig = {
   Auth: {
     Cognito: {
@@ -43,7 +50,7 @@ const authConfig: TypeAuthConfig = {
       userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
       loginWith: { email: true },
     },
-    storage: AsyncStorage,
+    storage,
   },
 };
 

--- a/app/services/authHelper/_execute.ts
+++ b/app/services/authHelper/_execute.ts
@@ -1,6 +1,3 @@
-import '@aws-amplify/react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Amplify } from 'aws-amplify';
 import {
   signIn as cognitoSignIn,
   signOut as cognitoSignOut,
@@ -9,15 +6,15 @@ import {
 } from 'aws-amplify/auth';
 
 import type {
-  TypeAmplifyClient,
-  TypeAuthConfig,
-  TypeAuthStorage,
   TypeSignInResult,
   TypeSignInValues,
   TypeSignUpResult,
   TypeSignUpValues,
   TypeVerifyValues,
 } from '../../lib/types/typeService';
+import { ensureAmplifyConfigured } from './configureAmplify';
+
+ensureAmplifyConfigured();
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -31,26 +28,6 @@ const isSignUpResponse = (value: unknown): value is TypeSignUpResult =>
 /* -----------------------------------------------
  * Cognito Auth ヘルパー
  * ----------------------------------------------- */
-
-/*
- * Amplify 設定
- */
-const amplifyClient: TypeAmplifyClient = Amplify as unknown as TypeAmplifyClient;
-
-const storage: TypeAuthStorage = AsyncStorage;
-
-const authConfig: TypeAuthConfig = {
-  Auth: {
-    Cognito: {
-      userPoolId: 'ap-northeast-1_ukr54toDk',
-      userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
-      loginWith: { email: true },
-    },
-    storage,
-  },
-};
-
-amplifyClient.configure(authConfig);
 
 /*
  * Sign In 処理

--- a/app/services/authHelper/configureAmplify.ts
+++ b/app/services/authHelper/configureAmplify.ts
@@ -1,20 +1,9 @@
 import '@aws-amplify/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Amplify } from 'aws-amplify';
+import { cognitoUserPoolsTokenProvider } from 'aws-amplify/auth/cognito';
 
-import type { TypeAmplifyClient, TypeAuthConfig, TypeAuthStorage } from '../../lib/types/typeService';
-
-const nativeStorage: TypeAuthStorage = {
-  async getItem(key: string) {
-    return AsyncStorage.getItem(key);
-  },
-  async setItem(key: string, value: string) {
-    await AsyncStorage.setItem(key, value);
-  },
-  async removeItem(key: string) {
-    await AsyncStorage.removeItem(key);
-  },
-};
+import type { TypeAmplifyClient, TypeAuthConfig } from '../../lib/types/typeService';
 
 const authConfig: TypeAuthConfig = {
   Auth: {
@@ -23,7 +12,6 @@ const authConfig: TypeAuthConfig = {
       userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
       loginWith: { email: true },
     },
-    storage: nativeStorage,
   },
 };
 
@@ -31,6 +19,7 @@ let isConfigured = false;
 
 export const ensureAmplifyConfigured = (): TypeAmplifyClient => {
   if (!isConfigured) {
+    cognitoUserPoolsTokenProvider.setKeyValueStorage(AsyncStorage);
     (Amplify as unknown as TypeAmplifyClient).configure(authConfig);
     isConfigured = true;
   }

--- a/app/services/authHelper/configureAmplify.ts
+++ b/app/services/authHelper/configureAmplify.ts
@@ -11,7 +11,9 @@ const authConfig: TypeAuthConfig = {
       userPoolId: 'ap-northeast-1_ukr54toDk',
       userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
       loginWith: { email: true },
+      region: 'ap-northeast-1',
     },
+    storage: AsyncStorage,
   },
 };
 

--- a/app/services/authHelper/configureAmplify.ts
+++ b/app/services/authHelper/configureAmplify.ts
@@ -1,0 +1,39 @@
+import '@aws-amplify/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Amplify } from 'aws-amplify';
+
+import type { TypeAmplifyClient, TypeAuthConfig, TypeAuthStorage } from '../../lib/types/typeService';
+
+const nativeStorage: TypeAuthStorage = {
+  async getItem(key: string) {
+    return AsyncStorage.getItem(key);
+  },
+  async setItem(key: string, value: string) {
+    await AsyncStorage.setItem(key, value);
+  },
+  async removeItem(key: string) {
+    await AsyncStorage.removeItem(key);
+  },
+};
+
+const authConfig: TypeAuthConfig = {
+  Auth: {
+    Cognito: {
+      userPoolId: 'ap-northeast-1_ukr54toDk',
+      userPoolClientId: '7qccrkdu7aq97so0cj0d61j0kv',
+      loginWith: { email: true },
+    },
+    storage: nativeStorage,
+  },
+};
+
+let isConfigured = false;
+
+export const ensureAmplifyConfigured = (): TypeAmplifyClient => {
+  if (!isConfigured) {
+    (Amplify as unknown as TypeAmplifyClient).configure(authConfig);
+    isConfigured = true;
+  }
+
+  return Amplify as unknown as TypeAmplifyClient;
+};

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,9 @@
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
+import '@aws-amplify/react-native';
 import { registerRootComponent } from 'expo';
-import { Platform } from 'react-native';
 
 import App from './app/App';
-
-if (Platform.OS !== 'web') {
-  // Amplify needs native random values polyfilled on iOS/Android
-  void import('@aws-amplify/react-native').then(({ loadGetRandomValues }) => {
-    loadGetRandomValues();
-  });
-}
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,


### PR DESCRIPTION
## Summary
- load Amplify's React Native polyfills at app startup
- configure Cognito auth to use AsyncStorage for native platforms
- extend auth helper typings to capture storage configuration

## Testing
- yarn lint *(fails: package missing from lockfile; install required)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929abda967c8324ac4d49c87cedf78c)