### PR TITLE
Add dynamic Storybook catalogs for SVG icons and logos

### DIFF
--- a/app/components/layouts/header/_headerHome.tsx
+++ b/app/components/layouts/header/_headerHome.tsx
@@ -27,7 +27,7 @@ const HeaderHome: React.FC<TypeHeaderHome> = (props) => {
             goToInfo();
           }}
         >
-          <IconLogin />
+          <IconLogin size={34} />
         </Pressable>
       </View>
     </View>

--- a/app/components/svg/icon/_iconLogin.tsx
+++ b/app/components/svg/icon/_iconLogin.tsx
@@ -6,7 +6,7 @@ import { color as mixinColor } from '../../../lib/mixin';
 import type { TypeIcon } from '../../../lib/types/typeComponents';
 import type React from 'react';
 
-const IconLogin: React.FC<TypeIcon> = ({ color = mixinColor.gray, size = 34 }) => {
+const IconLogin: React.FC<TypeIcon> = ({ color = mixinColor.gray, size = 24 }) => {
   const styles = StyleSheet.create({
     svgColor: {
       backgroundColor: mixinColor.white,

--- a/app/components/svg/logo/_logo.tsx
+++ b/app/components/svg/logo/_logo.tsx
@@ -5,8 +5,8 @@ import { color as mixinColor } from '../../../lib/mixin';
 import type { TypeLogo } from '../../../lib/types/typeComponents';
 import type React from 'react';
 
-const Logo: React.FC<TypeLogo> = ({ color = mixinColor.black, width = 85, height = 35 }) => (
-  <Svg fill='none' height={height} viewBox='0 0 85 35' width={width}>
+const Logo: React.FC<TypeLogo> = ({ color = mixinColor.black, width = 100, height = 35 }) => (
+  <Svg fill='none' height={height} viewBox='0 0 95 30' width={width}>
     <Text fill={color} fontSize='30' fontWeight='bold' transform='translate(0 28)'>
       LOGO
     </Text>

--- a/stories/svg/Icon.stories.tsx
+++ b/stories/svg/Icon.stories.tsx
@@ -1,23 +1,37 @@
-import { View } from 'react-native';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
-import { styles } from '../../.storybook/styles';
-import { IconAbout } from '../../app/components/svg/icon';
+import * as Icons from '../../app/components/svg/icon';
+import { styles as storyStyles } from '../../.storybook/styles';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+const iconEntries = Object.entries(Icons).sort(([a], [b]) => a.localeCompare(b));
+
+const IconCatalog: React.FC = () => (
+  <ScrollView style={storyStyles.container} contentContainerStyle={catalogStyles.grid}>
+    {iconEntries.map(([name, IconComponent]) => (
+      <View key={name} style={catalogStyles.item}>
+        <IconComponent />
+        <Text style={catalogStyles.label}>{name}</Text>
+      </View>
+    ))}
+  </ScrollView>
+);
+
 const meta = {
   title: 'Svg/Icon',
-  component: IconAbout,
+  component: IconCatalog,
   decorators: [
     (Story) => (
-      <View style={styles.container}>
+      <View style={storyStyles.container}>
         <Story />
       </View>
     ),
   ],
   tags: ['autodocs'],
   argTypes: {},
-} satisfies Meta;
+} satisfies Meta<typeof IconCatalog>;
 
 export default meta;
 
@@ -26,3 +40,28 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {},
 };
+
+const catalogStyles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 8,
+  },
+  item: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderRadius: 12,
+    margin: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    shadowColor: '#00000022',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+});

--- a/stories/svg/Icon.stories.tsx
+++ b/stories/svg/Icon.stories.tsx
@@ -1,22 +1,23 @@
-import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
-import * as Icons from '../../app/components/svg/icon';
 import { styles as storyStyles } from '../../.storybook/styles';
+import * as Icons from '../../app/components/svg/icon';
+import { color } from '../../app/lib/mixin';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import type React from 'react';
 
 const iconEntries = Object.entries(Icons).sort(([a], [b]) => a.localeCompare(b));
 
 const IconCatalog: React.FC = () => (
-  <ScrollView style={storyStyles.container} contentContainerStyle={catalogStyles.grid}>
+  <View style={[catalogStyles.grid, storyStyles.container]}>
     {iconEntries.map(([name, IconComponent]) => (
       <View key={name} style={catalogStyles.item}>
         <IconComponent />
         <Text style={catalogStyles.label}>{name}</Text>
       </View>
     ))}
-  </ScrollView>
+  </View>
 );
 
 const meta = {
@@ -43,24 +44,24 @@ export const Default: Story = {
 
 const catalogStyles = StyleSheet.create({
   grid: {
+    alignItems: 'center',
     flexDirection: 'row',
     flexWrap: 'wrap',
     padding: 8,
   },
   item: {
     alignItems: 'center',
-    backgroundColor: 'white',
-    borderRadius: 12,
-    margin: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    shadowColor: '#00000022',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
+    backgroundColor: color.white,
+    margin: 1,
+    padding: 12,
+    shadowColor: color.black,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
     shadowRadius: 4,
   },
   label: {
-    fontSize: 14,
+    color: color.black,
+    fontSize: 10,
     fontWeight: '600',
     marginTop: 8,
   },

--- a/stories/svg/Logo.stories.tsx
+++ b/stories/svg/Logo.stories.tsx
@@ -1,22 +1,23 @@
-import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
-import * as Logos from '../../app/components/svg/logo';
 import { styles as storyStyles } from '../../.storybook/styles';
+import * as Logos from '../../app/components/svg/logo';
+import { color } from '../../app/lib/mixin';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import type React from 'react';
 
 const logoEntries = Object.entries(Logos).sort(([a], [b]) => a.localeCompare(b));
 
 const LogoCatalog: React.FC = () => (
-  <ScrollView style={storyStyles.container} contentContainerStyle={catalogStyles.grid}>
+  <View style={[catalogStyles.grid, storyStyles.container]}>
     {logoEntries.map(([name, LogoComponent]) => (
       <View key={name} style={catalogStyles.item}>
-        <LogoComponent width={120} height={48} />
+        <LogoComponent />
         <Text style={catalogStyles.label}>{name}</Text>
       </View>
     ))}
-  </ScrollView>
+  </View>
 );
 
 const meta = {
@@ -43,24 +44,24 @@ export const Default: Story = {
 
 const catalogStyles = StyleSheet.create({
   grid: {
+    alignItems: 'center',
     flexDirection: 'row',
     flexWrap: 'wrap',
     padding: 8,
   },
   item: {
     alignItems: 'center',
-    backgroundColor: 'white',
-    borderRadius: 12,
-    margin: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    shadowColor: '#00000022',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
+    backgroundColor: color.white,
+    margin: 1,
+    padding: 12,
+    shadowColor: color.black,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
     shadowRadius: 4,
   },
   label: {
-    fontSize: 14,
+    color: color.black,
+    fontSize: 10,
     fontWeight: '600',
     marginTop: 8,
   },

--- a/stories/svg/Logo.stories.tsx
+++ b/stories/svg/Logo.stories.tsx
@@ -1,23 +1,37 @@
-import { View } from 'react-native';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
-import { styles } from '../../.storybook/styles';
-import { Logo } from '../../app/components/svg/logo';
+import * as Logos from '../../app/components/svg/logo';
+import { styles as storyStyles } from '../../.storybook/styles';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+const logoEntries = Object.entries(Logos).sort(([a], [b]) => a.localeCompare(b));
+
+const LogoCatalog: React.FC = () => (
+  <ScrollView style={storyStyles.container} contentContainerStyle={catalogStyles.grid}>
+    {logoEntries.map(([name, LogoComponent]) => (
+      <View key={name} style={catalogStyles.item}>
+        <LogoComponent width={120} height={48} />
+        <Text style={catalogStyles.label}>{name}</Text>
+      </View>
+    ))}
+  </ScrollView>
+);
+
 const meta = {
   title: 'Svg/Logo',
-  component: Logo,
+  component: LogoCatalog,
   decorators: [
     (Story) => (
-      <View style={styles.container}>
+      <View style={storyStyles.container}>
         <Story />
       </View>
     ),
   ],
   tags: ['autodocs'],
   argTypes: {},
-} satisfies Meta;
+} satisfies Meta<typeof LogoCatalog>;
 
 export default meta;
 
@@ -26,3 +40,28 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {},
 };
+
+const catalogStyles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 8,
+  },
+  item: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderRadius: 12,
+    margin: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    shadowColor: '#00000022',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+});


### PR DESCRIPTION
## Summary
- display all exported SVG icons in a catalog-style Storybook story to automatically include new assets
- display all exported SVG logos in a similar catalog layout
- simplify visual inspection of newly added SVG components without manual story updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0627f0b48324a29ab9c4084d649c)