### PR TITLE
Ensure Android select trigger opens picker

### DIFF
--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Keyboard, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
 import ErrorText from './_errorText';
@@ -53,7 +53,10 @@ const SelectBox = <TFieldValues extends FieldValues>({
 
   const openPicker = () => {
     Keyboard.dismiss();
-    pickerRef.current?.togglePicker(true);
+    setTimeout(() => {
+      pickerRef.current?.togglePicker?.(true);
+      pickerRef.current?.focus?.();
+    }, 0);
   };
 
   const handleValueChange = buildValueChangeHandler(controller.field.onChange);
@@ -62,28 +65,30 @@ const SelectBox = <TFieldValues extends FieldValues>({
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
 
-      <Pressable
-        accessibilityRole='button'
-        disabled={isDisabled}
-        onPress={openPicker}
-        style={triggerStyles}
-      >
-        <Text style={triggerTextStyles}>{displayLabel}</Text>
-      </Pressable>
+      <View style={styles.triggerWrapper}>
+        <RNPickerSelect
+          disabled={isDisabled}
+          doneText={doneText}
+          items={options}
+          onValueChange={handleValueChange}
+          placeholder={{ label: placeholder, value: '' }}
+          ref={(ref) => {
+            pickerRef.current = ref;
+          }}
+          style={pickerSelectStyles ?? baseSelectStyles}
+          useNativeAndroidPickerStyle={false}
+          value={toPickerValue(selectedValue)}
+        />
 
-      <RNPickerSelect
-        disabled={isDisabled}
-        doneText={doneText}
-        items={options}
-        onValueChange={handleValueChange}
-        placeholder={{ label: placeholder, value: '' }}
-        ref={(ref) => {
-          pickerRef.current = ref;
-        }}
-        style={pickerSelectStyles ?? baseSelectStyles}
-        useNativeAndroidPickerStyle={false}
-        value={toPickerValue(selectedValue)}
-      />
+        <Pressable
+          accessibilityRole='button'
+          disabled={isDisabled}
+          onPress={openPicker}
+          style={triggerStyles}
+        >
+          <Text style={triggerTextStyles}>{displayLabel}</Text>
+        </Pressable>
+      </View>
 
       <ErrorText errorText={errorText} />
     </View>
@@ -91,6 +96,9 @@ const SelectBox = <TFieldValues extends FieldValues>({
 };
 
 const styles = StyleSheet.create({
+  triggerWrapper: {
+    position: 'relative',
+  },
   selectTrigger: {
     alignItems: 'center',
     backgroundColor: color.white,
@@ -128,9 +136,12 @@ const baseSelectStyles = {
     padding: 0,
   },
   inputAndroid: {
-    height: 0,
+    backgroundColor: 'transparent',
+    height: '100%',
     opacity: 0,
     padding: 0,
+    position: 'absolute',
+    width: '100%',
   },
   inputWeb: {
     height: '100%',
@@ -141,13 +152,16 @@ const baseSelectStyles = {
   placeholder: {
     color: color.gray100,
   },
-  viewContainer: {
-    height: '100%',
-    width: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-  },
+  viewContainer: Platform.select({
+    android: {
+      ...StyleSheet.absoluteFillObject,
+      pointerEvents: 'none',
+    },
+    default: {
+      ...StyleSheet.absoluteFillObject,
+      pointerEvents: 'box-none',
+    },
+  }),
   modalViewMiddle: {
     backgroundColor: color.white,
   },

--- a/app/components/form/_selectBox.tsx
+++ b/app/components/form/_selectBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Keyboard, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
 import ErrorText from './_errorText';
@@ -53,10 +53,7 @@ const SelectBox = <TFieldValues extends FieldValues>({
 
   const openPicker = () => {
     Keyboard.dismiss();
-    setTimeout(() => {
-      pickerRef.current?.togglePicker?.(true);
-      pickerRef.current?.focus?.();
-    }, 0);
+    pickerRef.current?.togglePicker(true);
   };
 
   const handleValueChange = buildValueChangeHandler(controller.field.onChange);
@@ -65,30 +62,28 @@ const SelectBox = <TFieldValues extends FieldValues>({
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
 
-      <View style={styles.triggerWrapper}>
-        <RNPickerSelect
-          disabled={isDisabled}
-          doneText={doneText}
-          items={options}
-          onValueChange={handleValueChange}
-          placeholder={{ label: placeholder, value: '' }}
-          ref={(ref) => {
-            pickerRef.current = ref;
-          }}
-          style={pickerSelectStyles ?? baseSelectStyles}
-          useNativeAndroidPickerStyle={false}
-          value={toPickerValue(selectedValue)}
-        />
+      <Pressable
+        accessibilityRole='button'
+        disabled={isDisabled}
+        onPress={openPicker}
+        style={triggerStyles}
+      >
+        <Text style={triggerTextStyles}>{displayLabel}</Text>
+      </Pressable>
 
-        <Pressable
-          accessibilityRole='button'
-          disabled={isDisabled}
-          onPress={openPicker}
-          style={triggerStyles}
-        >
-          <Text style={triggerTextStyles}>{displayLabel}</Text>
-        </Pressable>
-      </View>
+      <RNPickerSelect
+        disabled={isDisabled}
+        doneText={doneText}
+        items={options}
+        onValueChange={handleValueChange}
+        placeholder={{ label: placeholder, value: '' }}
+        ref={(ref) => {
+          pickerRef.current = ref;
+        }}
+        style={pickerSelectStyles ?? baseSelectStyles}
+        useNativeAndroidPickerStyle={false}
+        value={toPickerValue(selectedValue)}
+      />
 
       <ErrorText errorText={errorText} />
     </View>
@@ -96,9 +91,6 @@ const SelectBox = <TFieldValues extends FieldValues>({
 };
 
 const styles = StyleSheet.create({
-  triggerWrapper: {
-    position: 'relative',
-  },
   selectTrigger: {
     alignItems: 'center',
     backgroundColor: color.white,
@@ -136,12 +128,9 @@ const baseSelectStyles = {
     padding: 0,
   },
   inputAndroid: {
-    backgroundColor: 'transparent',
-    height: '100%',
+    height: 0,
     opacity: 0,
     padding: 0,
-    position: 'absolute',
-    width: '100%',
   },
   inputWeb: {
     height: '100%',
@@ -152,16 +141,13 @@ const baseSelectStyles = {
   placeholder: {
     color: color.gray100,
   },
-  viewContainer: Platform.select({
-    android: {
-      ...StyleSheet.absoluteFillObject,
-      pointerEvents: 'none',
-    },
-    default: {
-      ...StyleSheet.absoluteFillObject,
-      pointerEvents: 'box-none',
-    },
-  }),
+  viewContainer: {
+    height: '100%',
+    width: '100%',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
   modalViewMiddle: {
     backgroundColor: color.white,
   },

--- a/app/components/form/_selectBoxNew.tsx
+++ b/app/components/form/_selectBoxNew.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { Keyboard, Platform, StyleSheet, View } from 'react-native';
+import RNPickerSelect from 'react-native-picker-select';
+
+import ErrorText from './_errorText';
+import Label from './_label';
+import { color } from '../../lib/mixin';
+import { useRHFController } from '../../services/formHelper';
+
+import type { TypeSelectBox } from '../../lib/types/typeComponents';
+import type { ComponentProps } from 'react';
+import type { FieldValues } from 'react-hook-form';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+/* -----------------------------------------------
+ * セレクトボックス (クロスプラットフォーム)
+ * ----------------------------------------------- */
+
+const SelectBoxNew = <TFieldValues extends FieldValues>({
+  containerStyle,
+  control,
+  disabled = false,
+  doneText,
+  errorText,
+  label,
+  name,
+  options,
+  pickerSelectStyles,
+  placeholder = '選択してください',
+  placeholderTextStyle,
+  rules,
+  triggerStyle,
+  valueTextStyle,
+}: TypeSelectBox<TFieldValues>) => {
+  const { controller } = useRHFController({ control, name, rules });
+
+  const selectedValue = getSelectedValue(controller.field.value);
+  const hasError = Boolean(errorText);
+  const isDisabled = isSelectDisabled(disabled);
+
+  const mergedPickerStyles = React.useMemo(
+    () => buildPickerStyles({
+      baseStyles: baseSelectStyles,
+      pickerSelectStyles,
+      triggerStyle,
+      valueTextStyle,
+      placeholderTextStyle,
+      hasError,
+      isDisabled,
+    }),
+    [pickerSelectStyles, triggerStyle, valueTextStyle, placeholderTextStyle, hasError, isDisabled],
+  );
+
+  const handleValueChange = buildValueChangeHandler(controller.field.onChange);
+
+  return (
+    <View style={containerStyle}>
+      <Label {...{ label, rules }} />
+
+      <RNPickerSelect
+        disabled={isDisabled}
+        doneText={doneText}
+        items={options}
+        onOpen={Keyboard.dismiss}
+        onValueChange={handleValueChange}
+        placeholder={{ label: placeholder, value: '' }}
+        style={mergedPickerStyles}
+        useNativeAndroidPickerStyle={false}
+        value={toPickerValue(selectedValue)}
+      />
+
+      <ErrorText errorText={errorText} />
+    </View>
+  );
+};
+
+const baseInputStyle: TextStyle = {
+  alignItems: 'center',
+  backgroundColor: color.white,
+  borderColor: color.gray100,
+  borderRadius: 8,
+  borderWidth: 1,
+  color: color.black,
+  flexDirection: 'row',
+  fontSize: 14,
+  minHeight: 44,
+  paddingHorizontal: 12,
+  paddingVertical: 10,
+};
+
+const baseSelectStyles = {
+  inputIOS: baseInputStyle,
+  inputAndroid: {
+    ...baseInputStyle,
+    paddingVertical: Platform.Version >= 30 ? 10 : 8,
+  },
+  inputWeb: {
+    ...baseInputStyle,
+    outlineStyle: 'none',
+  },
+  placeholder: {
+    color: color.gray100,
+    fontSize: 14,
+  },
+  viewContainer: {
+    width: '100%',
+  },
+  iconContainer: {
+    height: '100%',
+    justifyContent: 'center',
+    right: 12,
+  },
+  modalViewMiddle: {
+    backgroundColor: color.white,
+  },
+  modalViewBottom: {
+    backgroundColor: color.white,
+  },
+  done: {
+    color: color.primary,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+} satisfies NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
+
+const buildPickerStyles = ({
+  baseStyles,
+  pickerSelectStyles,
+  triggerStyle,
+  valueTextStyle,
+  placeholderTextStyle,
+  hasError,
+  isDisabled,
+}: {
+  baseStyles: NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
+  pickerSelectStyles: ComponentProps<typeof RNPickerSelect>['style'];
+  triggerStyle: StyleProp<ViewStyle> | undefined;
+  valueTextStyle: StyleProp<TextStyle> | undefined;
+  placeholderTextStyle: StyleProp<TextStyle> | undefined;
+  hasError: boolean;
+  isDisabled: boolean;
+}): NonNullable<ComponentProps<typeof RNPickerSelect>['style']> => {
+  const errorInputBorder: ViewStyle | undefined = hasError ? { borderColor: color.red } : undefined;
+  const disabledInput: ViewStyle | TextStyle | undefined = isDisabled
+    ? { backgroundColor: color.gray100, color: color.white }
+    : undefined;
+
+  const mergedInput = (base: TextStyle) =>
+    StyleSheet.flatten([base, triggerStyle, valueTextStyle, errorInputBorder, disabledInput]);
+
+  const mergedPlaceholder = StyleSheet.flatten([
+    baseStyles.placeholder,
+    placeholderTextStyle,
+    isDisabled ? { color: color.white } : null,
+  ]);
+
+  return {
+    inputIOS: StyleSheet.flatten([mergedInput(baseStyles.inputIOS as TextStyle), pickerSelectStyles?.inputIOS]),
+    inputAndroid: StyleSheet.flatten([
+      mergedInput(baseStyles.inputAndroid as TextStyle),
+      pickerSelectStyles?.inputAndroid,
+    ]),
+    inputWeb: StyleSheet.flatten([mergedInput(baseStyles.inputWeb as TextStyle), pickerSelectStyles?.inputWeb]),
+    placeholder: mergedPlaceholder,
+    viewContainer: StyleSheet.flatten([baseStyles.viewContainer, pickerSelectStyles?.viewContainer]),
+    iconContainer: StyleSheet.flatten([baseStyles.iconContainer, pickerSelectStyles?.iconContainer]),
+    modalViewMiddle: StyleSheet.flatten([baseStyles.modalViewMiddle, pickerSelectStyles?.modalViewMiddle]),
+    modalViewBottom: StyleSheet.flatten([baseStyles.modalViewBottom, pickerSelectStyles?.modalViewBottom]),
+    done: StyleSheet.flatten([baseStyles.done, pickerSelectStyles?.done]),
+  };
+};
+
+const buildValueChangeHandler = (
+  onChange: ((value: string) => void) | undefined,
+): ((selected: string | null) => void) => {
+  if (!onChange) {
+    return () => undefined;
+  }
+  return (selected: string | null) => {
+    onChange(selected ?? '');
+  };
+};
+
+const getSelectedValue = (rawValue: unknown): string => {
+  return ensureString(rawValue);
+};
+
+const isSelectDisabled = (disabled: boolean): boolean => {
+  return disabled;
+};
+
+const ensureString = (rawValue: unknown): string => {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
+  return '';
+};
+
+const toPickerValue = (value: string): string | null => {
+  if (value === '') {
+    return null;
+  }
+  return value;
+};
+
+export default SelectBoxNew;

--- a/app/components/form/_selectBoxNew.tsx
+++ b/app/components/form/_selectBoxNew.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Keyboard, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Keyboard, Platform, StyleSheet, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
 import ErrorText from './_errorText';
@@ -7,7 +7,7 @@ import Label from './_label';
 import { color } from '../../lib/mixin';
 import { useRHFController } from '../../services/formHelper';
 
-import type { TypeSelectBox, TypeSelectBoxOption } from '../../lib/types/typeComponents';
+import type { TypeSelectBox } from '../../lib/types/typeComponents';
 import type { ComponentProps } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
@@ -29,36 +29,17 @@ const SelectBoxNew = <TFieldValues extends FieldValues>({
   placeholder = '選択してください',
   placeholderTextStyle,
   rules,
-  triggerStyle,
   valueTextStyle,
 }: TypeSelectBox<TFieldValues>) => {
   const pickerRef = React.useRef<RNPickerSelect | null>(null);
-  const isWeb = Platform.OS === 'web';
   const { controller } = useRHFController({ control, name, rules });
+
+  const isWeb = Platform.OS === 'web';
 
   const selectedValue = getSelectedValue(controller.field.value);
   const hasError = Boolean(errorText);
   const isDisabled = isSelectDisabled(disabled);
-
   const selectedOption = options.find((option) => option.value === selectedValue);
-  const isPlaceholder = selectedOption == null;
-  const displayLabel = getDisplayLabel(selectedOption, placeholder);
-
-  const triggerStyles = React.useMemo(
-    () => buildTriggerStyles({ triggerStyle, hasError, isDisabled }),
-    [triggerStyle, hasError, isDisabled],
-  );
-
-  const triggerTextStyles = React.useMemo(
-    () =>
-      buildTriggerTextStyles({
-        isPlaceholder,
-        placeholderTextStyle,
-        valueTextStyle,
-        isDisabled,
-      }),
-    [isPlaceholder, placeholderTextStyle, valueTextStyle, isDisabled],
-  );
 
   const mergedPickerStyles = React.useMemo(
     () =>
@@ -75,12 +56,6 @@ const SelectBoxNew = <TFieldValues extends FieldValues>({
   );
 
   const handleValueChange = buildValueChangeHandler(controller.field.onChange);
-
-  const openPicker = () => {
-    if (isWeb) return;
-    Keyboard.dismiss();
-    pickerRef.current?.togglePicker(true);
-  };
 
   const pickerElement = (
     <RNPickerSelect
@@ -102,68 +77,45 @@ const SelectBoxNew = <TFieldValues extends FieldValues>({
   return (
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
-
-      {isWeb ? (
-        pickerElement
-      ) : (
-        <>
-          <Pressable
-            accessibilityRole='button'
-            disabled={isDisabled}
-            onPress={openPicker}
-            style={triggerStyles}
-          >
-            <Text style={triggerTextStyles}>{displayLabel}</Text>
-          </Pressable>
-
-          {pickerElement}
-        </>
-      )}
-
+      {pickerElement}
       <ErrorText errorText={errorText} />
     </View>
   );
 };
 
-const baseTriggerStyle: ViewStyle = {
-  alignItems: 'center',
-  backgroundColor: color.white,
-  borderColor: color.gray100,
-  borderRadius: 8,
-  borderWidth: 1,
-  flexDirection: 'row',
-  minHeight: 44,
-  paddingHorizontal: 12,
-  paddingVertical: 10,
-};
-
-const baseValueTextStyle: TextStyle = {
-  color: color.black,
-  fontSize: 14,
-};
-
-const hiddenInput: TextStyle = {
-  height: 0,
-  opacity: 0,
-  padding: 0,
-};
-
 const baseNativeSelectStyles = {
-  inputIOS: hiddenInput,
-  inputAndroid: hiddenInput,
+  inputIOS: {
+    alignItems: 'center',
+    backgroundColor: color.white,
+    borderColor: color.gray100,
+    borderRadius: 8,
+    borderWidth: 1,
+    color: color.black,
+    flexDirection: 'row',
+    fontSize: 14,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  inputAndroid: {
+    alignItems: 'center',
+    backgroundColor: color.white,
+    borderColor: color.gray100,
+    borderRadius: 8,
+    borderWidth: 1,
+    color: color.black,
+    flexDirection: 'row',
+    fontSize: 14,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
   placeholder: {
     color: color.gray100,
     fontSize: 14,
   },
   viewContainer: {
-    height: '100%',
     width: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    pointerEvents: 'none',
   },
   modalViewMiddle: {
     backgroundColor: color.white,
@@ -180,7 +132,17 @@ const baseNativeSelectStyles = {
 
 const baseWebSelectStyles = {
   inputWeb: {
-    ...baseTriggerStyle,
+    alignItems: 'center',
+    backgroundColor: color.white,
+    borderColor: color.gray100,
+    borderRadius: 8,
+    borderWidth: 1,
+    color: color.black,
+    flexDirection: 'row',
+    fontSize: 14,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
     outlineStyle: 'none',
   },
   placeholder: {
@@ -225,13 +187,13 @@ const buildPickerStyles = ({
   isDisabled: boolean;
   isWeb: boolean;
 }): NonNullable<ComponentProps<typeof RNPickerSelect>['style']> => {
-  const errorInputBorder: ViewStyle | undefined = hasError && isWeb ? { borderColor: color.red } : undefined;
-  const disabledInput: ViewStyle | TextStyle | undefined = isDisabled && isWeb
+  const errorInputBorder: ViewStyle | undefined = hasError ? { borderColor: color.red } : undefined;
+  const disabledInput: ViewStyle | TextStyle | undefined = isDisabled
     ? { backgroundColor: color.gray100, color: color.white }
     : undefined;
 
-  const mergedWebInput = (base: TextStyle) =>
-    StyleSheet.flatten([base, valueTextStyle, errorInputBorder, disabledInput]);
+  const mergedInput = (base: TextStyle) =>
+    StyleSheet.flatten([base, valueTextStyle, errorInputBorder, disabledInput, isWeb ? null : { paddingVertical: 10 }]);
 
   const mergedPlaceholder = StyleSheet.flatten([
     baseStyles.placeholder,
@@ -240,12 +202,12 @@ const buildPickerStyles = ({
   ]);
 
   return {
-    inputIOS: StyleSheet.flatten([baseStyles.inputIOS as TextStyle, pickerSelectStyles?.inputIOS]),
+    inputIOS: StyleSheet.flatten([mergedInput(baseStyles.inputIOS as TextStyle), pickerSelectStyles?.inputIOS]),
     inputAndroid: StyleSheet.flatten([
-      baseStyles.inputAndroid as TextStyle,
+      mergedInput(baseStyles.inputAndroid as TextStyle),
       pickerSelectStyles?.inputAndroid,
     ]),
-    inputWeb: StyleSheet.flatten([mergedWebInput(baseStyles.inputWeb as TextStyle), pickerSelectStyles?.inputWeb]),
+    inputWeb: StyleSheet.flatten([mergedInput(baseStyles.inputWeb as TextStyle), pickerSelectStyles?.inputWeb]),
     placeholder: mergedPlaceholder,
     viewContainer: StyleSheet.flatten([baseStyles.viewContainer, pickerSelectStyles?.viewContainer]),
     iconContainer: StyleSheet.flatten([baseStyles.iconContainer, pickerSelectStyles?.iconContainer]),
@@ -272,79 +234,6 @@ const getSelectedValue = (rawValue: unknown): string => {
 
 const isSelectDisabled = (disabled: boolean): boolean => {
   return disabled;
-};
-
-const buildTriggerStyles = ({
-  triggerStyle,
-  hasError,
-  isDisabled,
-}: {
-  triggerStyle: StyleProp<ViewStyle> | undefined;
-  hasError: boolean;
-  isDisabled: boolean;
-}): StyleProp<ViewStyle>[] => {
-  const styles: StyleProp<ViewStyle>[] = [baseTriggerStyle];
-
-  if (triggerStyle != null) {
-    styles.push(triggerStyle);
-  }
-
-  if (hasError) {
-    styles.push({ borderColor: color.red });
-  }
-
-  if (isDisabled) {
-    styles.push({ backgroundColor: color.gray100 });
-  }
-
-  return styles;
-};
-
-const buildTriggerTextStyles = ({
-  isPlaceholder,
-  placeholderTextStyle,
-  valueTextStyle,
-  isDisabled,
-}: {
-  isPlaceholder: boolean;
-  placeholderTextStyle: StyleProp<TextStyle> | undefined;
-  valueTextStyle: StyleProp<TextStyle> | undefined;
-  isDisabled: boolean;
-}): StyleProp<TextStyle>[] => {
-  const styles: StyleProp<TextStyle>[] = [];
-
-  if (isPlaceholder) {
-    styles.push({ ...baseValueTextStyle, color: color.gray100 });
-    if (placeholderTextStyle != null) {
-      styles.push(placeholderTextStyle);
-    }
-    if (isDisabled) {
-      styles.push({ color: color.white });
-    }
-    return styles;
-  }
-
-  styles.push(baseValueTextStyle);
-
-  if (valueTextStyle != null) {
-    styles.push(valueTextStyle);
-  }
-
-  if (isDisabled) {
-    styles.push({ color: color.white });
-  }
-
-  return styles;
-};
-
-const getDisplayLabel = (
-  selectedOption: TypeSelectBoxOption | undefined,
-  placeholder: string,
-): string => {
-  if (selectedOption == null) {
-    return placeholder;
-  }
-  return selectedOption.label ?? placeholder;
 };
 
 const ensureString = (rawValue: unknown): string => {

--- a/app/components/form/_selectBoxNew.tsx
+++ b/app/components/form/_selectBoxNew.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Keyboard, Platform, StyleSheet, View } from 'react-native';
+import { Keyboard, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 
 import ErrorText from './_errorText';
@@ -7,7 +7,7 @@ import Label from './_label';
 import { color } from '../../lib/mixin';
 import { useRHFController } from '../../services/formHelper';
 
-import type { TypeSelectBox } from '../../lib/types/typeComponents';
+import type { TypeSelectBox, TypeSelectBoxOption } from '../../lib/types/typeComponents';
 import type { ComponentProps } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
@@ -32,70 +32,155 @@ const SelectBoxNew = <TFieldValues extends FieldValues>({
   triggerStyle,
   valueTextStyle,
 }: TypeSelectBox<TFieldValues>) => {
+  const pickerRef = React.useRef<RNPickerSelect | null>(null);
+  const isWeb = Platform.OS === 'web';
   const { controller } = useRHFController({ control, name, rules });
 
   const selectedValue = getSelectedValue(controller.field.value);
   const hasError = Boolean(errorText);
   const isDisabled = isSelectDisabled(disabled);
 
+  const selectedOption = options.find((option) => option.value === selectedValue);
+  const isPlaceholder = selectedOption == null;
+  const displayLabel = getDisplayLabel(selectedOption, placeholder);
+
+  const triggerStyles = React.useMemo(
+    () => buildTriggerStyles({ triggerStyle, hasError, isDisabled }),
+    [triggerStyle, hasError, isDisabled],
+  );
+
+  const triggerTextStyles = React.useMemo(
+    () =>
+      buildTriggerTextStyles({
+        isPlaceholder,
+        placeholderTextStyle,
+        valueTextStyle,
+        isDisabled,
+      }),
+    [isPlaceholder, placeholderTextStyle, valueTextStyle, isDisabled],
+  );
+
   const mergedPickerStyles = React.useMemo(
-    () => buildPickerStyles({
-      baseStyles: baseSelectStyles,
-      pickerSelectStyles,
-      triggerStyle,
-      valueTextStyle,
-      placeholderTextStyle,
-      hasError,
-      isDisabled,
-    }),
-    [pickerSelectStyles, triggerStyle, valueTextStyle, placeholderTextStyle, hasError, isDisabled],
+    () =>
+      buildPickerStyles({
+        baseStyles: isWeb ? baseWebSelectStyles : baseNativeSelectStyles,
+        pickerSelectStyles,
+        valueTextStyle,
+        placeholderTextStyle,
+        hasError,
+        isDisabled,
+        isWeb,
+      }),
+    [isWeb, pickerSelectStyles, valueTextStyle, placeholderTextStyle, hasError, isDisabled],
   );
 
   const handleValueChange = buildValueChangeHandler(controller.field.onChange);
+
+  const openPicker = () => {
+    if (isWeb) return;
+    Keyboard.dismiss();
+    pickerRef.current?.togglePicker(true);
+  };
+
+  const pickerElement = (
+    <RNPickerSelect
+      disabled={isDisabled}
+      doneText={doneText}
+      items={options}
+      onOpen={Keyboard.dismiss}
+      onValueChange={handleValueChange}
+      placeholder={{ label: placeholder, value: '' }}
+      ref={(ref) => {
+        pickerRef.current = ref;
+      }}
+      style={mergedPickerStyles}
+      useNativeAndroidPickerStyle={false}
+      value={toPickerValue(selectedValue)}
+    />
+  );
 
   return (
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
 
-      <RNPickerSelect
-        disabled={isDisabled}
-        doneText={doneText}
-        items={options}
-        onOpen={Keyboard.dismiss}
-        onValueChange={handleValueChange}
-        placeholder={{ label: placeholder, value: '' }}
-        style={mergedPickerStyles}
-        useNativeAndroidPickerStyle={false}
-        value={toPickerValue(selectedValue)}
-      />
+      {isWeb ? (
+        pickerElement
+      ) : (
+        <>
+          <Pressable
+            accessibilityRole='button'
+            disabled={isDisabled}
+            onPress={openPicker}
+            style={triggerStyles}
+          >
+            <Text style={triggerTextStyles}>{displayLabel}</Text>
+          </Pressable>
+
+          {pickerElement}
+        </>
+      )}
 
       <ErrorText errorText={errorText} />
     </View>
   );
 };
 
-const baseInputStyle: TextStyle = {
+const baseTriggerStyle: ViewStyle = {
   alignItems: 'center',
   backgroundColor: color.white,
   borderColor: color.gray100,
   borderRadius: 8,
   borderWidth: 1,
-  color: color.black,
   flexDirection: 'row',
-  fontSize: 14,
   minHeight: 44,
   paddingHorizontal: 12,
   paddingVertical: 10,
 };
 
-const baseSelectStyles = {
-  inputIOS: baseInputStyle,
-  inputAndroid: {
-    ...baseInputStyle,
-    paddingVertical: Platform.Version >= 30 ? 10 : 8,
+const baseValueTextStyle: TextStyle = {
+  color: color.black,
+  fontSize: 14,
+};
+
+const hiddenInput: TextStyle = {
+  height: 0,
+  opacity: 0,
+  padding: 0,
+};
+
+const baseNativeSelectStyles = {
+  inputIOS: hiddenInput,
+  inputAndroid: hiddenInput,
+  placeholder: {
+    color: color.gray100,
+    fontSize: 14,
   },
+  viewContainer: {
+    height: '100%',
+    width: '100%',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    pointerEvents: 'none',
+  },
+  modalViewMiddle: {
+    backgroundColor: color.white,
+  },
+  modalViewBottom: {
+    backgroundColor: color.white,
+  },
+  done: {
+    color: color.primary,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+} satisfies NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
+
+const baseWebSelectStyles = {
   inputWeb: {
-    ...baseInputStyle,
+    ...baseTriggerStyle,
     outlineStyle: 'none',
   },
   placeholder: {
@@ -126,27 +211,27 @@ const baseSelectStyles = {
 const buildPickerStyles = ({
   baseStyles,
   pickerSelectStyles,
-  triggerStyle,
   valueTextStyle,
   placeholderTextStyle,
   hasError,
   isDisabled,
+  isWeb,
 }: {
   baseStyles: NonNullable<ComponentProps<typeof RNPickerSelect>['style']>;
   pickerSelectStyles: ComponentProps<typeof RNPickerSelect>['style'];
-  triggerStyle: StyleProp<ViewStyle> | undefined;
   valueTextStyle: StyleProp<TextStyle> | undefined;
   placeholderTextStyle: StyleProp<TextStyle> | undefined;
   hasError: boolean;
   isDisabled: boolean;
+  isWeb: boolean;
 }): NonNullable<ComponentProps<typeof RNPickerSelect>['style']> => {
-  const errorInputBorder: ViewStyle | undefined = hasError ? { borderColor: color.red } : undefined;
-  const disabledInput: ViewStyle | TextStyle | undefined = isDisabled
+  const errorInputBorder: ViewStyle | undefined = hasError && isWeb ? { borderColor: color.red } : undefined;
+  const disabledInput: ViewStyle | TextStyle | undefined = isDisabled && isWeb
     ? { backgroundColor: color.gray100, color: color.white }
     : undefined;
 
-  const mergedInput = (base: TextStyle) =>
-    StyleSheet.flatten([base, triggerStyle, valueTextStyle, errorInputBorder, disabledInput]);
+  const mergedWebInput = (base: TextStyle) =>
+    StyleSheet.flatten([base, valueTextStyle, errorInputBorder, disabledInput]);
 
   const mergedPlaceholder = StyleSheet.flatten([
     baseStyles.placeholder,
@@ -155,12 +240,12 @@ const buildPickerStyles = ({
   ]);
 
   return {
-    inputIOS: StyleSheet.flatten([mergedInput(baseStyles.inputIOS as TextStyle), pickerSelectStyles?.inputIOS]),
+    inputIOS: StyleSheet.flatten([baseStyles.inputIOS as TextStyle, pickerSelectStyles?.inputIOS]),
     inputAndroid: StyleSheet.flatten([
-      mergedInput(baseStyles.inputAndroid as TextStyle),
+      baseStyles.inputAndroid as TextStyle,
       pickerSelectStyles?.inputAndroid,
     ]),
-    inputWeb: StyleSheet.flatten([mergedInput(baseStyles.inputWeb as TextStyle), pickerSelectStyles?.inputWeb]),
+    inputWeb: StyleSheet.flatten([mergedWebInput(baseStyles.inputWeb as TextStyle), pickerSelectStyles?.inputWeb]),
     placeholder: mergedPlaceholder,
     viewContainer: StyleSheet.flatten([baseStyles.viewContainer, pickerSelectStyles?.viewContainer]),
     iconContainer: StyleSheet.flatten([baseStyles.iconContainer, pickerSelectStyles?.iconContainer]),
@@ -187,6 +272,79 @@ const getSelectedValue = (rawValue: unknown): string => {
 
 const isSelectDisabled = (disabled: boolean): boolean => {
   return disabled;
+};
+
+const buildTriggerStyles = ({
+  triggerStyle,
+  hasError,
+  isDisabled,
+}: {
+  triggerStyle: StyleProp<ViewStyle> | undefined;
+  hasError: boolean;
+  isDisabled: boolean;
+}): StyleProp<ViewStyle>[] => {
+  const styles: StyleProp<ViewStyle>[] = [baseTriggerStyle];
+
+  if (triggerStyle != null) {
+    styles.push(triggerStyle);
+  }
+
+  if (hasError) {
+    styles.push({ borderColor: color.red });
+  }
+
+  if (isDisabled) {
+    styles.push({ backgroundColor: color.gray100 });
+  }
+
+  return styles;
+};
+
+const buildTriggerTextStyles = ({
+  isPlaceholder,
+  placeholderTextStyle,
+  valueTextStyle,
+  isDisabled,
+}: {
+  isPlaceholder: boolean;
+  placeholderTextStyle: StyleProp<TextStyle> | undefined;
+  valueTextStyle: StyleProp<TextStyle> | undefined;
+  isDisabled: boolean;
+}): StyleProp<TextStyle>[] => {
+  const styles: StyleProp<TextStyle>[] = [];
+
+  if (isPlaceholder) {
+    styles.push({ ...baseValueTextStyle, color: color.gray100 });
+    if (placeholderTextStyle != null) {
+      styles.push(placeholderTextStyle);
+    }
+    if (isDisabled) {
+      styles.push({ color: color.white });
+    }
+    return styles;
+  }
+
+  styles.push(baseValueTextStyle);
+
+  if (valueTextStyle != null) {
+    styles.push(valueTextStyle);
+  }
+
+  if (isDisabled) {
+    styles.push({ color: color.white });
+  }
+
+  return styles;
+};
+
+const getDisplayLabel = (
+  selectedOption: TypeSelectBoxOption | undefined,
+  placeholder: string,
+): string => {
+  if (selectedOption == null) {
+    return placeholder;
+  }
+  return selectedOption.label ?? placeholder;
 };
 
 const ensureString = (rawValue: unknown): string => {


### PR DESCRIPTION
## Summary
- wrap the picker and trigger inside a relative container so the pressable stays on top
- keep the picker view container filling the trigger area while ignoring pointer events
- defer picker opening to the next tick for more reliable Android onPress handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c575158b883249981ce2ef76f64dd)