### PR TITLE
Adjust keyboard avoidance for layout scroll view

### DIFF
--- a/app/components/layouts/layout/_layout.tsx
+++ b/app/components/layouts/layout/_layout.tsx
@@ -1,4 +1,10 @@
-import { ScrollView, StyleSheet, View } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 import { color } from '../../../lib/mixin';
 
@@ -13,11 +19,22 @@ export const Layout: FC<TypeLayout> = (props) => {
   const { children } = props;
 
   return (
-    <View style={styles.container}>
-      <ScrollView contentContainerStyle={styles.children} keyboardShouldPersistTaps='handled'>
-        {children}
-      </ScrollView>
-    </View>
+    <KeyboardAvoidingView
+      behavior={Platform.select({ ios: 'padding', android: 'height', default: undefined })}
+      keyboardVerticalOffset={Platform.select({ ios: 0, android: 16, default: 0 })}
+      style={styles.container}
+    >
+      <View style={styles.inner}>
+        <ScrollView
+          automaticallyAdjustKeyboardInsets
+          contentContainerStyle={styles.children}
+          keyboardDismissMode='on-drag'
+          keyboardShouldPersistTaps='handled'
+        >
+          {children}
+        </ScrollView>
+      </View>
+    </KeyboardAvoidingView>
   );
 };
 
@@ -28,9 +45,13 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     width: '100%',
   },
+  inner: {
+    flex: 1,
+  },
   children: {
     flexGrow: 1,
     padding: 16,
+    paddingBottom: 32,
   },
 });
 


### PR DESCRIPTION
## Summary
- enable keyboard avoidance on both iOS and Android with a platform-specific behavior and offset
- allow the scroll view to adjust keyboard insets automatically and add extra bottom padding for form fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4a5eeb3083248d3feaf9b7743cf8)