### PR TITLE
Refactor dialog to meet complexity lint rule

### DIFF
--- a/app/components/dialog/_dialog.tsx
+++ b/app/components/dialog/_dialog.tsx
@@ -23,28 +23,20 @@ import type { TypeDialog } from '../../lib/types/typeComponents';
  * ダイアログ
  * ----------------------------------------------- */
 const DialogHeader = ({ title, description }: Pick<TypeDialog, 'title' | 'description'>) => {
-  const hasTitle = typeof title === 'string' && title.length > 0;
-  const hasDescription = typeof description === 'string' && description.length > 0;
-
-  if (!hasTitle && !hasDescription) return null;
-
-  const headerItems = [] as React.ReactNode[];
-
-  if (hasTitle) {
-    headerItems.push(
+  const headerItems = [
+    Boolean(title?.length) ? (
       <Text key='dialog-title' style={styles.title}>
         {title}
-      </Text>,
-    );
-  }
-
-  if (hasDescription) {
-    headerItems.push(
+      </Text>
+    ) : null,
+    Boolean(description?.length) ? (
       <Text key='dialog-description' style={styles.description}>
         {description}
-      </Text>,
-    );
-  }
+      </Text>
+    ) : null,
+  ].filter(Boolean);
+
+  if (headerItems.length === 0) return null;
 
   return <View style={styles.header}>{headerItems}</View>;
 };
@@ -240,7 +232,7 @@ const getDialogActionVisibility = ({
 });
 
 const hasDialogHeader = (title?: string, description?: string) =>
-  (title?.length ?? 0) > 0 || (description?.length ?? 0) > 0;
+  Boolean(title?.length) || Boolean(description?.length);
 
 const styles = StyleSheet.create({
   container: {

--- a/app/components/dialog/_dialog.tsx
+++ b/app/components/dialog/_dialog.tsx
@@ -23,22 +23,25 @@ import type { TypeDialog } from '../../lib/types/typeComponents';
  * ダイアログ
  * ----------------------------------------------- */
 const DialogHeader = ({ title, description }: Pick<TypeDialog, 'title' | 'description'>) => {
-  const headerItems = [
-    Boolean(title?.length) ? (
-      <Text key='dialog-title' style={styles.title}>
-        {title}
-      </Text>
-    ) : null,
-    Boolean(description?.length) ? (
-      <Text key='dialog-description' style={styles.description}>
-        {description}
-      </Text>
-    ) : null,
-  ].filter(Boolean);
+  const hasTitle = !!title?.length;
+  const hasDescription = !!description?.length;
 
-  if (headerItems.length === 0) return null;
+  if (!hasTitle && !hasDescription) return null;
 
-  return <View style={styles.header}>{headerItems}</View>;
+  return (
+    <View style={styles.header}>
+      {hasTitle ? (
+        <Text key='dialog-title' style={styles.title}>
+          {title}
+        </Text>
+      ) : null}
+      {hasDescription ? (
+        <Text key='dialog-description' style={styles.description}>
+          {description}
+        </Text>
+      ) : null}
+    </View>
+  );
 };
 
 const DialogContent = ({ children }: Pick<TypeDialog, 'children'>) => {
@@ -227,12 +230,12 @@ const getDialogActionVisibility = ({
   TypeDialog,
   'closeText' | 'eventText' | 'onClose' | 'onEvent'
 >) => ({
-  showCloseButton: Boolean(closeText) && Boolean(onClose),
-  showEventButton: Boolean(eventText) && Boolean(onEvent),
+  showCloseButton: !!closeText && !!onClose,
+  showEventButton: !!eventText && !!onEvent,
 });
 
 const hasDialogHeader = (title?: string, description?: string) =>
-  Boolean(title?.length) || Boolean(description?.length);
+  !!title?.length || !!description?.length;
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
## Summary
- simplify the dialog header rendering logic to reduce cyclomatic complexity
- factor dialog layout concerns into helper hooks to keep the layout hook within complexity limits

## Testing
- yarn lint *(fails locally: yarn command unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693252d9c90c8324b5be39192de01a51)