### PR TITLE
Inline option rows in custom checkbox and radio

### DIFF
--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -74,58 +74,62 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
     [],
   );
 
-  const CheckBoxOptionRow = ({
-    isDisabled,
-    isSelected,
-    labelStyle,
-    onPress,
-    optionLabel,
-  }: {
-    isDisabled: boolean;
-    isSelected: boolean;
-    labelStyle: StyleProp<TextStyle>;
-    onPress: () => void;
-    optionLabel: string;
-  }) => {
-    const animation = useSharedValue(isSelected ? 1 : 0);
+  const CheckBoxOptionRow = useMemo(
+    () =>
+      ({
+        isDisabled,
+        isSelected,
+        labelStyle,
+        onPress,
+        optionLabel,
+      }: {
+        isDisabled: boolean;
+        isSelected: boolean;
+        labelStyle: StyleProp<TextStyle>;
+        onPress: () => void;
+        optionLabel: string;
+      }) => {
+        const animation = useSharedValue(isSelected ? 1 : 0);
 
-    useEffect(() => {
-      animation.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
-    }, [animation, isSelected]);
+        useEffect(() => {
+          animation.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
+        }, [animation, isSelected]);
 
-    const animatedBackgroundStyle = useAnimatedStyle(() => ({
-      backgroundColor: interpolateColor(animation.value, [0, 1], [color.gray, color.primary]),
-    }));
+        const animatedBackgroundStyle = useAnimatedStyle(() => ({
+          backgroundColor: interpolateColor(animation.value, [0, 1], [color.gray, color.primary]),
+        }));
 
-    const animatedKnobStyle = useAnimatedStyle(() => ({
-      left: knobOffsetRange[0] + (knobOffsetRange[1] - knobOffsetRange[0]) * animation.value,
-    }));
+        const animatedKnobStyle = useAnimatedStyle(() => ({
+          left: knobOffsetRange[0] + (knobOffsetRange[1] - knobOffsetRange[0]) * animation.value,
+        }));
 
-    return (
-      <Pressable
-        accessibilityRole='checkbox'
-        accessibilityState={{ checked: isSelected }}
-        disabled={isDisabled}
-        onPress={onPress}
-        style={[styles.checkBoxRow, optionRowStyle]}
-      >
-        <Animated.View
-          style={[
-            styles.checkBoxBase,
-            animatedBackgroundStyle,
-            hasError ? styles.checkBoxError : null,
-            isDisabled ? styles.checkBoxDisabled : null,
-          ]}
-        >
-          <Animated.View
-            style={[styles.checkBoxKcob, animatedKnobStyle, isDisabled ? styles.checkBoxKnobDisabled : null]}
-          />
-        </Animated.View>
+        return (
+          <Pressable
+            accessibilityRole='checkbox'
+            accessibilityState={{ checked: isSelected }}
+            disabled={isDisabled}
+            onPress={onPress}
+            style={[styles.checkBoxRow, optionRowStyle]}
+          >
+            <Animated.View
+              style={[
+                styles.checkBoxBase,
+                animatedBackgroundStyle,
+                hasError ? styles.checkBoxError : null,
+                isDisabled ? styles.checkBoxDisabled : null,
+              ]}
+            >
+              <Animated.View
+                style={[styles.checkBoxKcob, animatedKnobStyle, isDisabled ? styles.checkBoxKnobDisabled : null]}
+              />
+            </Animated.View>
 
-        <Text style={labelStyle}>{optionLabel}</Text>
-      </Pressable>
-    );
-  };
+            <Text style={labelStyle}>{optionLabel}</Text>
+          </Pressable>
+        );
+      },
+    [hasError, knobOffsetRange, optionRowStyle],
+  );
 
   return (
     <View style={containerStyle}>

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -1,165 +1,112 @@
-import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import Animated, {
-  interpolate,
-  interpolateColor,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
 
 import ErrorText from './_errorText';
 import Label from './_label';
 import { color } from '../../lib/mixin';
 import { useRHFController } from '../../services/formHelper';
 
-import type { TypeCheckBoxCustom, TypeToggleCheckOption } from '../../lib/types/typeComponents';
+import type { TypeCheckBox } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
-import type { SharedValue } from 'react-native-reanimated';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 /* -----------------------------------------------
  * チェックボックスカスタム項目
  * ----------------------------------------------- */
 
-const TRACK_WIDTH = 48;
-const TRACK_HEIGHT = 28;
-const KNOB_SIZE = 22;
-const KNOB_MARGIN = (TRACK_HEIGHT - KNOB_SIZE) / 2;
-
-const ERROR_COLOR = color.red;
-const DISABLED_COLOR = color.gray100;
-const KNOB_MAX_TRANSLATE = TRACK_WIDTH - KNOB_SIZE - KNOB_MARGIN;
-
-const ToggleCheckOption = ({
-  label,
-  disabled = false,
-  isSelected,
-  onPress,
-  accessibilityState,
-  hasError,
-  activeColor,
-  inactiveColor,
-  knobColor,
-  optionRowStyle,
-  optionLabelStyle,
-  trackStyle,
-  knobStyle,
-}: TypeToggleCheckOption) => {
-  const progress: SharedValue<number> = useSharedValue<number>(isSelected ? 1 : 0);
-  const isDisabled = disabled;
-
-  React.useEffect(() => {
-    progress.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
-  }, [isSelected, progress]);
-
-  const trackAnimatedStyle = useAnimatedStyle(
-    (): { backgroundColor: string } => ({
-      backgroundColor: isDisabled
-        ? DISABLED_COLOR
-        : String(interpolateColor(progress.value, [0, 1], [inactiveColor, activeColor])),
-    }),
-    [activeColor, inactiveColor, isDisabled],
-  );
-
-  const knobAnimatedStyle = useAnimatedStyle(
-    (): { transform: { translateX: number }[] } => ({
-      transform: [
-        {
-          translateX: interpolate(progress.value, [0, 1], [KNOB_MARGIN, KNOB_MAX_TRANSLATE]),
-        },
-      ],
-    }),
-    [],
-  );
-
-  return (
-    <Pressable
-      accessibilityRole='checkbox'
-      accessibilityState={accessibilityState}
-      disabled={isDisabled}
-      onPress={onPress}
-      style={[styles.optionRow, optionRowStyle]}
-    >
-      <Animated.View
-        style={[
-          styles.track,
-          hasError ? styles.trackError : styles.trackDefault,
-          trackAnimatedStyle,
-          trackStyle,
-        ]}
-      >
-        <Animated.View
-          style={[styles.knob, { backgroundColor: knobColor }, knobAnimatedStyle, knobStyle]}
-        />
-      </Animated.View>
-      <Text
-        style={[
-          styles.optionLabel,
-          optionLabelStyle,
-          isDisabled ? styles.optionLabelDisabled : null,
-        ]}
-      >
-        {label}
-      </Text>
-    </Pressable>
-  );
-};
-
 const CheckBoxCustom = <TFieldValues extends FieldValues>({
-  activeColor: activeColorProp,
   containerStyle,
   control,
-  disabled,
+  disabled = false,
   errorText,
-  inactiveColor: inactiveColorProp,
-  knobColor: knobColorProp,
   label,
   name,
   optionListStyle,
   optionRowStyle,
-  optionLabelStyle,
   options,
   rules,
-  trackStyle,
-  knobStyle,
-}: TypeCheckBoxCustom<TFieldValues>) => {
+}: TypeCheckBox<TFieldValues>) => {
   const { controller } = useRHFController({ control, name, rules });
-  const controllerValue = controller.field.value;
-
-  const selectedValues = React.useMemo(() => getSelectedValues(controllerValue), [controllerValue]);
-
   const hasError = Boolean(errorText);
 
-  const activeColor = activeColorProp ?? color.primary;
-  const inactiveColor = inactiveColorProp ?? '#d1d5db';
-  const knobColor = knobColorProp ?? color.white;
+  const getSelectedValues = (value: unknown): string[] => {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value as string[];
+  };
+  const selectedValues = getSelectedValues(controller.field.value);
+
+  const getIsOptionDisabled = (optionDisabled: boolean | undefined, disabled: boolean): boolean => {
+    return optionDisabled === true || disabled;
+  };
+
+  const handleToggleOption = (
+    optionValue: string,
+    selectedValues: string[],
+    onChange: (value: string[]) => void,
+  ) => {
+    if (selectedValues.includes(optionValue)) {
+      onChange(selectedValues.filter((selected) => selected !== optionValue));
+      return;
+    }
+    onChange([...selectedValues, optionValue]);
+  };
+
+  /*
+   * 適用スタイル
+   */
+  const getOptionLabelStyle = (disabled: boolean) => {
+    if (!disabled) {
+      return null;
+    }
+    return styles.checkBoxTextDisabled;
+  };
+
+  const getKnobStyle = (selected: boolean, disabled: boolean) => {
+    const buildStyles: StyleProp<ViewStyle>[] = [];
+
+    if (selected) {
+      buildStyles.push(styles.checkBoxKcobSelected);
+    }
+
+    if (disabled) {
+      buildStyles.push(styles.checkBoxKnobDisabled);
+    }
+
+    return buildStyles;
+  };
 
   return (
     <View style={containerStyle}>
       <Label {...{ label, rules }} />
-      <View style={[styles.optionList, optionListStyle]}>
+      <View style={[styles.checkBoxGroup, optionListStyle]}>
         {options.map((option) => {
           const isSelected = selectedValues.includes(option.value);
           const isDisabled = getIsOptionDisabled(option.disabled, disabled);
           return (
-            <ToggleCheckOption
+            <Pressable
+              accessibilityRole='checkbox'
               accessibilityState={{ checked: isSelected }}
-              activeColor={activeColor}
               disabled={isDisabled}
-              hasError={hasError}
-              inactiveColor={inactiveColor}
-              isSelected={isSelected}
               key={option.key ?? option.value}
-              knobColor={knobColor}
-              knobStyle={knobStyle}
-              label={option.label}
               onPress={() => {
                 handleToggleOption(option.value, selectedValues, controller.field.onChange);
               }}
-              optionLabelStyle={optionLabelStyle}
-              optionRowStyle={optionRowStyle}
-              trackStyle={trackStyle}
-            />
+              style={[styles.checkBoxRow, optionRowStyle]}
+            >
+              <View
+                style={[
+                  styles.checkBoxBase,
+                  isSelected ? styles.checkBoxSelected : null,
+                  hasError ? styles.checkBoxError : null,
+                  isDisabled ? styles.checkBoxDisabled : null,
+                ]}
+              >
+                <View style={[styles.checkBoxKcob, getKnobStyle(isSelected, isDisabled)]} />
+              </View>
+
+              <Text style={getOptionLabelStyle(isDisabled)}>{option.label}</Text>
+            </Pressable>
           );
         })}
       </View>
@@ -168,70 +115,53 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   );
 };
 
-const getSelectedValues = (value: unknown): string[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value as string[];
-};
-
-const getIsOptionDisabled = (
-  optionDisabled: boolean | undefined,
-  disabled: boolean | undefined,
-): boolean => {
-  return optionDisabled === true || disabled === true;
-};
-
-const handleToggleOption = (
-  optionValue: string,
-  selectedValues: string[],
-  onChange: (value: string[]) => void,
-) => {
-  if (selectedValues.includes(optionValue)) {
-    onChange(selectedValues.filter((selected) => selected !== optionValue));
-    return;
-  }
-  onChange([...selectedValues, optionValue]);
-};
-
 const styles = StyleSheet.create({
-  optionList: {
+  checkBoxGroup: {
     rowGap: 12,
   },
-  optionRow: {
+  checkBoxRow: {
     alignItems: 'center',
     columnGap: 12,
     flexDirection: 'row',
   },
-  track: {
-    borderRadius: TRACK_HEIGHT / 2,
+  checkBoxBase: {
+    backgroundColor: color.gray,
+    borderColor: color.white,
+    borderRadius: 15,
     borderWidth: 1,
-    height: TRACK_HEIGHT,
+    height: 30,
     justifyContent: 'center',
-    paddingHorizontal: KNOB_MARGIN,
-    width: TRACK_WIDTH,
+    width: 50,
   },
-  trackDefault: {
-    borderColor: color.transparent,
+  checkBoxTextDisabled: {
+    color: color.gray100,
   },
-  trackError: {
-    borderColor: ERROR_COLOR,
-  },
-  knob: {
-    borderRadius: KNOB_SIZE / 2,
-    elevation: 2,
-    height: KNOB_SIZE,
+  checkBoxKcob: {
+    backgroundColor: color.white,
+    borderRadius: 22,
+    height: 22,
+    left: 5,
     shadowColor: color.black,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 1.41,
-    width: KNOB_SIZE,
+    width: 22,
   },
-  optionLabel: {
-    fontSize: 14,
+  checkBoxKcobSelected: {
+    left: 23,
   },
-  optionLabelDisabled: {
-    color: color.gray100,
+  checkBoxKnobDisabled: {
+    backgroundColor: color.white,
+  },
+  checkBoxSelected: {
+    backgroundColor: color.primary,
+  },
+  checkBoxError: {
+    borderColor: color.red,
+  },
+  checkBoxDisabled: {
+    backgroundColor: color.gray100,
+    borderColor: color.gray100,
   },
 });
 

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -5,7 +5,7 @@ import Label from './_label';
 import { color } from '../../lib/mixin';
 import { useRHFController } from '../../services/formHelper';
 
-import type { TypeCheckBox } from '../../lib/types/typeComponents';
+import type { TypeCheckBoxCustom } from '../../lib/types/typeComponents';
 import type { FieldValues } from 'react-hook-form';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -24,7 +24,7 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
   optionRowStyle,
   options,
   rules,
-}: TypeCheckBox<TFieldValues>) => {
+}: TypeCheckBoxCustom<TFieldValues>) => {
   const { controller } = useRHFController({ control, name, rules });
   const hasError = Boolean(errorText);
 
@@ -126,8 +126,8 @@ const styles = StyleSheet.create({
   },
   checkBoxBase: {
     backgroundColor: color.gray,
-    borderColor: color.white,
-    borderRadius: 15,
+    borderColor: color.gray,
+    borderRadius: 20,
     borderWidth: 1,
     height: 30,
     justifyContent: 'center',

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -66,57 +66,61 @@ const RadioBoxCustom = <TFieldValues extends FieldValues>({
     [],
   );
 
-  const RadioBoxOptionRow = ({
-    isDisabled,
-    isSelected,
-    labelStyle,
-    onPress,
-    optionLabel,
-  }: {
-    isDisabled: boolean;
-    isSelected: boolean;
-    labelStyle: StyleProp<TextStyle>;
-    onPress: () => void;
-    optionLabel: string;
-  }) => {
-    const animation = useSharedValue(isSelected ? 1 : 0);
+  const RadioBoxOptionRow = useMemo(
+    () =>
+      ({
+        isDisabled,
+        isSelected,
+        labelStyle,
+        onPress,
+        optionLabel,
+      }: {
+        isDisabled: boolean;
+        isSelected: boolean;
+        labelStyle: StyleProp<TextStyle>;
+        onPress: () => void;
+        optionLabel: string;
+      }) => {
+        const animation = useSharedValue(isSelected ? 1 : 0);
 
-    useEffect(() => {
-      animation.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
-    }, [animation, isSelected]);
+        useEffect(() => {
+          animation.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
+        }, [animation, isSelected]);
 
-    const animatedBackgroundStyle = useAnimatedStyle(() => ({
-      backgroundColor: interpolateColor(animation.value, [0, 1], [color.gray, color.primary]),
-    }));
+        const animatedBackgroundStyle = useAnimatedStyle(() => ({
+          backgroundColor: interpolateColor(animation.value, [0, 1], [color.gray, color.primary]),
+        }));
 
-    const animatedKnobStyle = useAnimatedStyle(() => ({
-      left: knobOffsetRange[0] + (knobOffsetRange[1] - knobOffsetRange[0]) * animation.value,
-    }));
+        const animatedKnobStyle = useAnimatedStyle(() => ({
+          left: knobOffsetRange[0] + (knobOffsetRange[1] - knobOffsetRange[0]) * animation.value,
+        }));
 
-    return (
-      <Pressable
-        accessibilityRole='radio'
-        accessibilityState={{ selected: isSelected }}
-        disabled={isDisabled}
-        onPress={onPress}
-        style={[styles.radioRow, optionRowStyle]}
-      >
-        <Animated.View
-          style={[
-            styles.radioBoxBase,
-            animatedBackgroundStyle,
-            hasError ? styles.radioBoxError : null,
-            isDisabled ? styles.radioBoxDisabled : null,
-          ]}
-        >
-          <Animated.View
-            style={[styles.radioBoxKcob, animatedKnobStyle, isDisabled ? styles.checkBoxKcobDisabled : null]}
-          />
-        </Animated.View>
-        <Text style={labelStyle}>{optionLabel}</Text>
-      </Pressable>
-    );
-  };
+        return (
+          <Pressable
+            accessibilityRole='radio'
+            accessibilityState={{ selected: isSelected }}
+            disabled={isDisabled}
+            onPress={onPress}
+            style={[styles.radioRow, optionRowStyle]}
+          >
+            <Animated.View
+              style={[
+                styles.radioBoxBase,
+                animatedBackgroundStyle,
+                hasError ? styles.radioBoxError : null,
+                isDisabled ? styles.radioBoxDisabled : null,
+              ]}
+            >
+              <Animated.View
+                style={[styles.radioBoxKcob, animatedKnobStyle, isDisabled ? styles.checkBoxKcobDisabled : null]}
+              />
+            </Animated.View>
+            <Text style={labelStyle}>{optionLabel}</Text>
+          </Pressable>
+        );
+      },
+    [hasError, knobOffsetRange, optionRowStyle],
+  );
 
   return (
     <View style={containerStyle}>

--- a/app/lib/types/typeComponents/_form.ts
+++ b/app/lib/types/typeComponents/_form.ts
@@ -1,5 +1,5 @@
 import type { Control, FieldValues, Path, RegisterOptions } from 'react-hook-form';
-import type { PressableProps, StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
+import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
 import type { Item } from 'react-native-picker-select';
 
 /* -----------------------------------------------
@@ -14,25 +14,6 @@ export type TypeBoxOption = {
   label?: string;
   value: string;
   key?: string | number;
-};
-
-type TypeToggleCustomBase<TFieldValues extends FieldValues> = {
-  label?: string;
-  control?: Control<TFieldValues>;
-  disabled?: boolean;
-  name?: Path<TFieldValues>;
-  options: TypeBoxOption[];
-  rules?: RegisterOptions<TFieldValues, Path<TFieldValues>>;
-  errorText?: TypeErrorText;
-  containerStyle?: StyleProp<ViewStyle>;
-  optionListStyle?: StyleProp<ViewStyle>;
-  optionRowStyle?: StyleProp<ViewStyle>;
-  optionLabelStyle?: StyleProp<TextStyle>;
-  trackStyle?: StyleProp<ViewStyle>;
-  knobStyle?: StyleProp<ViewStyle>;
-  activeColor?: string;
-  inactiveColor?: string;
-  knobColor?: string;
 };
 
 /*
@@ -54,24 +35,7 @@ export type TypeCheckBox<TFieldValues extends FieldValues> = {
 /*
  * type チェックボックスカスタム項目
  */
-export type TypeCheckBoxCustom<TFieldValues extends FieldValues> =
-  TypeToggleCustomBase<TFieldValues>;
-
-export type TypeToggleCheckOption = {
-  label?: string;
-  disabled?: boolean;
-  isSelected: boolean;
-  onPress: () => void;
-  accessibilityState: PressableProps['accessibilityState'];
-  hasError: boolean;
-  activeColor: string;
-  inactiveColor: string;
-  knobColor: string;
-  optionRowStyle: TypeCheckBoxCustom<FieldValues>['optionRowStyle'];
-  optionLabelStyle: TypeCheckBoxCustom<FieldValues>['optionLabelStyle'];
-  trackStyle: TypeCheckBoxCustom<FieldValues>['trackStyle'];
-  knobStyle: TypeCheckBoxCustom<FieldValues>['knobStyle'];
-};
+export type TypeCheckBoxCustom<TFieldValues extends FieldValues> = TypeCheckBox<TFieldValues>;
 
 /*
  * type エラーテキスト
@@ -119,24 +83,7 @@ export type TypeRadioBox<TFieldValues extends FieldValues> = {
 /*
  * type ラヂオボックスカスタム項目
  */
-export type TypeRadioBoxCustom<TFieldValues extends FieldValues> =
-  TypeToggleCustomBase<TFieldValues>;
-
-export type TypeToggleRadioOption = {
-  label?: string;
-  disabled?: boolean;
-  isSelected: boolean;
-  onPress: () => void;
-  accessibilityState: PressableProps['accessibilityState'];
-  hasError: boolean;
-  activeColor: string;
-  inactiveColor: string;
-  knobColor: string;
-  optionRowStyle: TypeRadioBoxCustom<FieldValues>['optionRowStyle'];
-  optionLabelStyle: TypeRadioBoxCustom<FieldValues>['optionLabelStyle'];
-  trackStyle: TypeRadioBoxCustom<FieldValues>['trackStyle'];
-  knobStyle: TypeRadioBoxCustom<FieldValues>['knobStyle'];
-};
+export type TypeRadioBoxCustom<TFieldValues extends FieldValues> = TypeRadioBox<TFieldValues>;
 
 /*
  * type セレクトボックス項目


### PR DESCRIPTION
## Summary
- inline the checkbox option row logic inside `CheckBoxCustom` while keeping the reanimated animations
- mirror the same inline approach for `RadioBoxCustom` to simplify component structure

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330207cc4083248d190eb944b53a03)