### PR TITLE
Update toast stories to listen for toast service events

### DIFF
--- a/stories/toast/Toast.stories.tsx
+++ b/stories/toast/Toast.stories.tsx
@@ -3,13 +3,29 @@ import { StyleSheet, View } from 'react-native';
 
 import { styles } from '../../.storybook/styles.ts';
 import Button from '../../app/components/button/_button.tsx';
-import ToastComponent from '../../app/components/toast/_toast.tsx';
+import ToastProvider from '../../app/components/toast/_toastProvider.tsx';
+import { showToast } from '../../app/components/toast/_toastService.ts';
+import type { TypeToastOptions } from '../../app/lib/types/typeComponents';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+const ToastPreview = (args: TypeToastOptions) => {
+  const handleShowToast = () => {
+    showToast({ ...args });
+  };
+
+  return (
+    <ToastProvider>
+      <View style={gapStyles.gap}>
+        <Button onPress={handleShowToast} title='Show Toast' />
+      </View>
+    </ToastProvider>
+  );
+};
+
 const meta = {
   title: 'Toast/Toast',
-  component: ToastComponent,
+  component: ToastPreview,
   decorators: [
     (Story) => (
       <View style={[styles.container, styles.center]}>
@@ -37,39 +53,16 @@ const meta = {
       description: 'バリエーション',
     },
   },
-} satisfies Meta<typeof ToastComponent>;
+} satisfies Meta<typeof ToastPreview>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
 const baseArgs = {
-  visible: false,
   message: 'Toast Message',
   position: 'bottom' as const,
   duration: 2000,
-};
-
-const ToastPreview = (args: Story['args']) => {
-  const [visible, setVisible] = React.useState(false);
-
-  return (
-    <View style={gapStyles.gap}>
-      <Button
-        onPress={() => {
-          setVisible(true);
-        }}
-        title='Show Toast'
-      />
-      <ToastComponent
-        {...args}
-        onHide={() => {
-          setVisible(false);
-        }}
-        visible={visible}
-      />
-    </View>
-  );
 };
 
 export const BasicToast: Story = {

--- a/stories/toast/Toast.stories.tsx
+++ b/stories/toast/Toast.stories.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { styles } from '../../.storybook/styles.ts';
 import Button from '../../app/components/button/_button.tsx';
 import ToastProvider from '../../app/components/toast/_toastProvider.tsx';
 import { showToast } from '../../app/components/toast/_toastService.ts';
-import type { TypeToastOptions } from '../../app/lib/types/typeComponents';
 
+import type { TypeToastOptions } from '../../app/lib/types/typeComponents';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 const ToastPreview = (args: TypeToastOptions) => {
@@ -16,7 +15,7 @@ const ToastPreview = (args: TypeToastOptions) => {
 
   return (
     <ToastProvider>
-      <View style={gapStyles.gap}>
+      <View style={buttonStyle.container}>
         <Button onPress={handleShowToast} title='Show Toast' />
       </View>
     </ToastProvider>
@@ -109,6 +108,12 @@ export const ErrorToast: Story = {
   render: (args) => <ToastPreview {...args} />,
 };
 
-const gapStyles = StyleSheet.create({
-  gap: { gap: 12, width: '100%' },
+const buttonStyle = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: 12,
+    height: 300,
+    justifyContent: 'center',
+    width: '100%',
+  },
 });


### PR DESCRIPTION
## Summary
- update Toast story to display toasts by calling the shared showToast service
- wrap Storybook preview in ToastProvider so the event listener receives toast events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934134bad70832482d7cd6e1378c14e)