### PR TITLE
Consolidate app providers into single wrapper

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,12 +1,11 @@
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { enableScreens } from 'react-native-screens';
 
 import { Navigation } from './navigation';
 import { useSplashMinDuration } from './services/appRootService';
-import { ToastProvider } from './services/providerService';
+import { AppProvider } from './services/providerService';
 
 import type React from 'react';
 
@@ -17,12 +16,10 @@ const App: React.FC = () => {
 
   return (
     <GestureHandlerRootView style={styles.container}>
-      <SafeAreaProvider>
-        <ToastProvider>
-          <Navigation />
-          <StatusBar style='auto' />
-        </ToastProvider>
-      </SafeAreaProvider>
+      <AppProvider>
+        <Navigation />
+        <StatusBar style='auto' />
+      </AppProvider>
     </GestureHandlerRootView>
   );
 };

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -13,7 +13,7 @@ import type React from 'react';
  * AppRoot
  * ----------------------------------------------- */
 
-enableScreens(); // App起動前に呼び出す
+enableScreens(); // アプリ起動前に呼び出す
 
 const App: React.FC = () => {
   useSplashMinDuration(2000); // アプリ起動時、スプラッシュ画像を指定ミリ秒表示する処理

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -5,9 +5,13 @@ import { enableScreens } from 'react-native-screens';
 
 import { Navigation } from './navigation';
 import { useSplashMinDuration } from './services/appRootService';
-import { AppProvider } from './services/providerService';
+import { AppRootProvider } from './services/providerService';
 
 import type React from 'react';
+
+/* -----------------------------------------------
+ * AppRoot
+ * ----------------------------------------------- */
 
 enableScreens(); // App起動前に呼び出す
 
@@ -16,10 +20,10 @@ const App: React.FC = () => {
 
   return (
     <GestureHandlerRootView style={styles.container}>
-      <AppProvider>
+      <AppRootProvider>
         <Navigation />
         <StatusBar style='auto' />
-      </AppProvider>
+      </AppRootProvider>
     </GestureHandlerRootView>
   );
 };

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,4 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { enableScreens } from 'react-native-screens';
 
 import { Navigation } from './navigation';
@@ -19,19 +17,11 @@ const App: React.FC = () => {
   useSplashMinDuration(2000); // アプリ起動時、スプラッシュ画像を指定ミリ秒表示する処理
 
   return (
-    <GestureHandlerRootView style={styles.container}>
-      <AppRootProvider>
-        <Navigation />
-        <StatusBar style='auto' />
-      </AppRootProvider>
-    </GestureHandlerRootView>
+    <AppRootProvider>
+      <Navigation />
+      <StatusBar style='auto' />
+    </AppRootProvider>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
 
 export default App;

--- a/app/services/providerService/_appProvider.tsx
+++ b/app/services/providerService/_appProvider.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import ToastProvider from './_toastProvider';
+
+/* -----------------------------------------------
+ * アプリ全体のプロバイダーをまとめる
+ * ----------------------------------------------- */
+
+const AppProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <SafeAreaProvider>
+    <ToastProvider>{children}</ToastProvider>
+  </SafeAreaProvider>
+);
+
+export default AppProvider;

--- a/app/services/providerService/_appRootProvider.tsx
+++ b/app/services/providerService/_appRootProvider.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import ToastProvider from './_toastProvider';
 
+import type React from 'react';
+
 /* -----------------------------------------------
- * アプリ全体のプロバイダーをまとめる
+ * AppRoot用のプロバイダーをまとめる
  * ----------------------------------------------- */
 
-const AppProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+const AppRootProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
   <SafeAreaProvider>
     <ToastProvider>{children}</ToastProvider>
   </SafeAreaProvider>
 );
 
-export default AppProvider;
+export default AppRootProvider;

--- a/app/services/providerService/_appRootProvider.tsx
+++ b/app/services/providerService/_appRootProvider.tsx
@@ -1,3 +1,5 @@
+import { StyleSheet } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import ToastProvider from './_toastProvider';
@@ -9,9 +11,17 @@ import type React from 'react';
  * ----------------------------------------------- */
 
 const AppRootProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <SafeAreaProvider>
-    <ToastProvider>{children}</ToastProvider>
-  </SafeAreaProvider>
+  <GestureHandlerRootView style={styles.container}>
+    <SafeAreaProvider>
+      <ToastProvider>{children}</ToastProvider>
+    </SafeAreaProvider>
+  </GestureHandlerRootView>
 );
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 export default AppRootProvider;

--- a/app/services/providerService/index.ts
+++ b/app/services/providerService/index.ts
@@ -1,7 +1,7 @@
 /* -----------------------------------------------
  * プロバイダー用の処理まとめ
- *（App.tsx が複雑になりそうならここにプロバイダーを纏める）
+ * AppRootで使うプロバイダーは AppRootProvider に纏める
  * ----------------------------------------------- */
 
-export { default as AppProvider } from './_appProvider';
+export { default as AppRootProvider } from './_appRootProvider';
 export { default as ToastProvider } from './_toastProvider';

--- a/app/services/providerService/index.ts
+++ b/app/services/providerService/index.ts
@@ -3,4 +3,5 @@
  *（App.tsx が複雑になりそうならここにプロバイダーを纏める）
  * ----------------------------------------------- */
 
+export { default as AppProvider } from './_appProvider';
 export { default as ToastProvider } from './_toastProvider';


### PR DESCRIPTION
## Summary
- add an AppProvider that combines SafeAreaProvider and ToastProvider for the app
- update App.tsx to use the consolidated provider wrapper for navigation and status bar

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d93e4a74832499b1e457623f8adb)