### PR TITLE
Add Storybook color asset catalog for mixin styles

### DIFF
--- a/stories/lib/color.stories.tsx
+++ b/stories/lib/color.stories.tsx
@@ -1,12 +1,12 @@
 import { StyleSheet, Text, View } from 'react-native';
 
-import { styles as storyStyles } from '../../../.storybook/styles';
-import { color } from '../../../app/lib/mixin';
+import { styles as storyStyles } from '../../.storybook/styles';
+import { color } from '../../app/lib/mixin';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import type React from 'react';
 
-const colorEntries = Object.entries(color).sort(([a], [b]) => a.localeCompare(b));
+const colorEntries = Object.entries(color);
 
 const colorUsageSnippet = `import { color } from '../../../app/lib/mixin';\n\n${colorEntries
   .map(([name, value]) => `color.${name}; // ${String(value)}`)
@@ -25,7 +25,7 @@ const ColorCatalog: React.FC = () => (
 );
 
 const meta = {
-  title: 'Lib/Mixin/Styles',
+  title: 'Lib/Color',
   component: ColorCatalog,
   decorators: [
     (Story) => (
@@ -77,13 +77,13 @@ const catalogStyles = StyleSheet.create({
   },
   name: {
     color: color.primary,
-    fontSize: 12,
+    fontSize: 14,
     fontWeight: '600',
     marginTop: 8,
   },
   value: {
     color: color.gray50,
-    fontSize: 11,
+    fontSize: 12,
     marginTop: 4,
   },
 });

--- a/stories/lib/mixin/styles.stories.tsx
+++ b/stories/lib/mixin/styles.stories.tsx
@@ -1,0 +1,89 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { styles as storyStyles } from '../../../.storybook/styles';
+import { color } from '../../../app/lib/mixin';
+
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import type React from 'react';
+
+const colorEntries = Object.entries(color).sort(([a], [b]) => a.localeCompare(b));
+
+const colorUsageSnippet = `import { color } from '../../../app/lib/mixin';\n\n${colorEntries
+  .map(([name, value]) => `color.${name}; // ${String(value)}`)
+  .join('\n')}`;
+
+const ColorCatalog: React.FC = () => (
+  <View style={[catalogStyles.grid, storyStyles.container]}>
+    {colorEntries.map(([name, value]) => (
+      <View key={name} style={catalogStyles.item}>
+        <View style={[catalogStyles.swatch, { backgroundColor: value }]} />
+        <Text style={catalogStyles.name}>{name}</Text>
+        <Text style={catalogStyles.value}>{String(value)}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+const meta = {
+  title: 'Lib/Mixin/Styles',
+  component: ColorCatalog,
+  decorators: [
+    (Story) => (
+      <View style={storyStyles.container}>
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {},
+  parameters: {
+    docs: {
+      source: {
+        code: colorUsageSnippet,
+      },
+    },
+  },
+} satisfies Meta<typeof ColorCatalog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+const catalogStyles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    padding: 12,
+  },
+  item: {
+    backgroundColor: color.white,
+    borderColor: color.gray,
+    borderRadius: 8,
+    borderWidth: 1,
+    minWidth: 132,
+    padding: 10,
+  },
+  swatch: {
+    borderColor: color.gray,
+    borderRadius: 6,
+    borderWidth: 1,
+    height: 48,
+    width: '100%',
+  },
+  name: {
+    color: color.primary,
+    fontSize: 12,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  value: {
+    color: color.gray50,
+    fontSize: 11,
+    marginTop: 4,
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a visual Storybook catalog for the app color tokens so designers and developers can quickly inspect color assets.
- Match existing SVG/Logo story patterns so color tokens are discoverable in the same way as other asset catalogs.

### Description
- Add `stories/lib/mixin/styles.stories.tsx` which imports `color` from `app/lib/mixin`, sorts `Object.entries(color)`, and renders a swatch grid with token name and value.
- Include a docs `source` snippet showing the `import { color } from '../../../app/lib/mixin'` usage and `color.<token>` examples.
- Use the same `Meta`/`StoryObj` structure, `autodocs` tag, and a container decorator consistent with existing asset stories.

### Testing
- Ran `yarn eslint stories/lib/mixin/styles.stories.tsx --max-warnings=0` which passed.
- Ran `yarn prettier --check stories/lib/mixin/styles.stories.tsx` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf64dc36b08324904c53dadf88fe45)