### PR TITLE
ESLint: add total-functions no-unsafe-type-assertion rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactNative from 'eslint-plugin-react-native';
 import sonarjs from 'eslint-plugin-sonarjs';
+import totalFunctions from 'eslint-plugin-total-functions';
 import tseslint from 'typescript-eslint';
 
 /** @type {import('eslint').ESLint.Plugin} */
@@ -50,6 +51,7 @@ export default [
     plugins: {
       'react-native': reactNativePlugin,
       import: importPlugin,
+      'total-functions': totalFunctions,
     },
     settings: {
       react: {
@@ -148,15 +150,13 @@ export default [
       'max-depth': ['error', 5],
       'no-else-return': ['error'],
 
-      /* -------------------------------------------------------
-        'total-functions/no-unsafe-type-assertion': 'error'
-        が最新のESlintに対応してないため以下にて代替
-      ---------------------------------------------------------- */
       /* <Type> スタイルは警告、object literal の場合は許容 */
       '@typescript-eslint/consistent-type-assertions': [
         'warn',
         { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' },
       ],
+      /* 危険なasアサーションを禁止 */
+      'total-functions/no-unsafe-type-assertion': 'error',
       /* 型が"any"や"unknown"の値に対して、プロパティアクセスやメソッド呼び出しを行うと警告 */
       '@typescript-eslint/no-unsafe-member-access': 'error',
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react-native": "^5.0.0",
     "eslint-plugin-sonarjs": "^3.0.4",
     "eslint-plugin-storybook": "^10.1.10",
+    "eslint-plugin-total-functions": "^8.8.0",
     "husky": "^9.1.3",
     "lint-staged": "^15.2.8",
     "playwright": "^1.56.1",


### PR DESCRIPTION
### Motivation
- 危険な `as` 型アサーションを禁止するために `total-functions/no-unsafe-type-assertion` を有効化する目的です。

### Description
- `devDependencies` に `eslint-plugin-total-functions` を追加しました（`package.json` に `"eslint-plugin-total-functions": "^8.8.0"` を追記）。
- `eslint.config.js` に `import totalFunctions from 'eslint-plugin-total-functions'` を追加してプラグインを登録しました。 
- `eslint.config.js` のルールに `"total-functions/no-unsafe-type-assertion": "error"` を追加し、既存の `@typescript-eslint/consistent-type-assertions` と `@typescript-eslint/no-unsafe-member-access` は維持しました。

### Testing
- 実施したコマンドは `yarn add -D eslint-plugin-total-functions` と `yarn lint` です。 
- `yarn add -D eslint-plugin-total-functions` は npm レジストリへのアクセスが `403 Forbidden` となりパッケージ取得に失敗しました。 
- そのため `yarn lint` は `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eslint-plugin-total-functions'` により失敗し、ルール検出までは到達できませんでした。 
- レジストリアクセスが可能になりパッケージがインストールできれば `yarn lint` による `no-unsafe-type-assertion` の検出確認が可能です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce69b753c08324a1d5342a01fcec2a)