### PR TITLE
Fix ESLint/TS lint errors across components and stories

### DIFF
--- a/.storybook/mocks/react-native-reanimated.ts
+++ b/.storybook/mocks/react-native-reanimated.ts
@@ -145,7 +145,7 @@ const hexToRgb = (hex: string) => {
   if (normalized.length === 3) {
     normalized = normalized
       .split('')
-      .map((char) => char.repeat(2))
+      .map((char = '') => char.repeat(2))
       .join('');
   }
   const r = parseInt(normalized.slice(0, 2), 16);
@@ -155,7 +155,7 @@ const hexToRgb = (hex: string) => {
 };
 
 const rgbToHex = (r: number, g: number, b: number) =>
-  `#${[r, g, b].map((component) => component.toString(16).padStart(2, '0')).join('')}`;
+  `#${[r, g, b].map((component = 0) => component.toString(16).padStart(2, '0')).join('')}`;
 
 export type SharedValue<T> = { value: T };
 
@@ -171,7 +171,7 @@ export const useSharedValue = <T>(initialValue: T): SharedValue<T> => {
   if (ref.current == null) {
     ref.current = new SharedValueImpl<T>(initialValue);
   }
-  return ref.current as SharedValue<T>;
+  return ref.current;
 };
 
 let activeCollector: Set<CollectableSharedValue> | null = null;
@@ -220,14 +220,17 @@ export const withTiming = <T>(
   toValue: T,
   config: WithTimingConfig = {},
   callback?: (finished: boolean) => void,
-): T =>
-  ({
+): T => {
+  const animation = {
     __mockAnimationType: 'timing',
     toValue,
     duration: config.duration ?? 300,
     easing: config.easing,
     callback,
-  }) as TimingAnimation<T> as unknown as T;
+  } satisfies TimingAnimation<T>;
+
+  return animation as unknown as T;
+};
 
 export const interpolate = (
   value: number,

--- a/app/components/dialog/_dialog.tsx
+++ b/app/components/dialog/_dialog.tsx
@@ -30,7 +30,7 @@ import type { TypeDialog } from '../../lib/types/typeComponents';
 const DialogBackGround = ({
   onClose,
   notBackGroundPress,
-}: Pick<TypeDialog, 'onClose' | 'notBackGroundPress'>) => {
+}: Pick<TypeDialog, 'onClose' | 'notBackGroundPress'>): React.JSX.Element | null => {
   if (notBackGroundPress !== false) {
     return null;
   }
@@ -45,7 +45,7 @@ const DialogBackGround = ({
 /*
  * タイトル
  */
-const DialogTitle = ({ title }: Pick<TypeDialog, 'title'>) => {
+const DialogTitle = ({ title }: Pick<TypeDialog, 'title'>): React.JSX.Element | null => {
   const istitle = Boolean(title);
   if (!istitle) {
     return null;
@@ -61,7 +61,7 @@ const DialogTitle = ({ title }: Pick<TypeDialog, 'title'>) => {
 /*
  * チャイルドコンテンツ
  */
-const DialogChildren = ({ children }: Pick<TypeDialog, 'children'>) => {
+const DialogChildren = ({ children }: Pick<TypeDialog, 'children'>): React.JSX.Element | null => {
   const ischildren = Boolean(children);
   if (!ischildren) {
     return null;
@@ -87,7 +87,7 @@ const DialogBottom = ({
   eventText,
   onClose,
   onEvent,
-}: Pick<TypeDialog, 'closeText' | 'eventText' | 'onClose' | 'onEvent'>) => {
+}: Pick<TypeDialog, 'closeText' | 'eventText' | 'onClose' | 'onEvent'>): React.JSX.Element | null => {
   const isCloseText = Boolean(closeText);
   const isEventText = Boolean(eventText);
   if (!isCloseText && !isEventText) {

--- a/app/components/form/_checkBox.tsx
+++ b/app/components/form/_checkBox.tsx
@@ -39,7 +39,7 @@ const CheckBox = <TFieldValues extends FieldValues>({
     return optionDisabled === true || disabled;
   };
 
-  const getToggleValue = (value: string) => {
+  const getToggleValue = (value: string): string[] => {
     if (selectedValues.includes(value)) {
       return selectedValues.filter((selected) => selected !== value);
     }
@@ -49,14 +49,14 @@ const CheckBox = <TFieldValues extends FieldValues>({
   /*
    * 適用スタイル
    */
-  const getOptionLabelStyle = (disabled: boolean) => {
+  const getOptionLabelStyle = (disabled: boolean): object | null => {
     if (!disabled) {
       return null;
     }
     return styles.checkBoxTextDisabled;
   };
 
-  const getSelectedStyle = (disabled: boolean) => {
+  const getSelectedStyle = (disabled: boolean): object | null => {
     if (!disabled) {
       return null;
     }
@@ -68,16 +68,17 @@ const CheckBox = <TFieldValues extends FieldValues>({
       <Label {...{ label, rules }} />
       <View style={[styles.checkBoxGroup, optionListStyle]}>
         {options.map((option) => {
-          const isSelected = selectedValues.includes(option.value);
+          const optionValue = String(option.value);
+          const isSelected = selectedValues.includes(optionValue);
           const isDisabled = getIsOptionDisabled(option.disabled, disabled);
           return (
             <Pressable
               accessibilityRole='checkbox'
               accessibilityState={{ checked: isSelected }}
               disabled={isDisabled}
-              key={option.key ?? option.value}
+              key={option.key ?? optionValue}
               onPress={() => {
-                const toggleValue = getToggleValue(option.value);
+                const toggleValue = getToggleValue(optionValue);
                 controller.field.onChange(toggleValue);
               }}
               style={[styles.checkBoxRow, optionRowStyle]}

--- a/app/components/form/_checkBoxCustom.tsx
+++ b/app/components/form/_checkBoxCustom.tsx
@@ -60,7 +60,7 @@ const OptionRow: React.FC<TypeBoxCustomOption> = ({
     };
   });
 
-  const getOptionLabelStyle = (disabled: boolean) => {
+  const getOptionLabelStyle = (disabled: boolean): object | null => {
     if (!disabled) {
       return null;
     }
@@ -129,7 +129,7 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
     allDisabled: boolean,
   ): boolean => optionDisabled === true || allDisabled;
 
-  const getToggleValue = (value: string) => {
+  const getToggleValue = (value: string): string[] => {
     if (selectedValues.includes(value)) {
       return selectedValues.filter((selected) => selected !== value);
     }
@@ -141,7 +141,8 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
       <Label {...{ label, rules }} />
       <View style={[styles.checkBoxGroup, optionListStyle]}>
         {options.map((option) => {
-          const isSelected = selectedValues.includes(option.value);
+          const optionValue = String(option.value);
+          const isSelected = selectedValues.includes(optionValue);
           const isDisabled = getIsOptionDisabled(option.disabled, disabled);
 
           /*
@@ -152,14 +153,14 @@ const CheckBoxCustom = <TFieldValues extends FieldValues>({
               hasError={hasError}
               isDisabled={isDisabled}
               isSelected={isSelected}
-              key={option.key ?? option.value}
+              key={option.key ?? optionValue}
               label={option.label}
               onToggle={() => {
-                const toggleValue = getToggleValue(option.value);
+                const toggleValue = getToggleValue(optionValue);
                 controller.field.onChange(toggleValue);
               }}
               optionRowStyle={optionRowStyle}
-              value={option.value}
+              value={optionValue}
             />
           );
         })}

--- a/app/components/form/_errorText.tsx
+++ b/app/components/form/_errorText.tsx
@@ -8,7 +8,9 @@ import type { TypeErrorText } from '../../lib/types/typeComponents';
  * エラーテキスト
  * ----------------------------------------------- */
 
-const ErrorText: React.FC<{ errorText?: TypeErrorText }> = ({ errorText }) => {
+const ErrorText: React.FC<{ errorText?: TypeErrorText }> = ({
+  errorText,
+}): React.JSX.Element | null => {
   const isErrorText = Boolean(errorText);
   if (!isErrorText) {
     return null;

--- a/app/components/form/_label.tsx
+++ b/app/components/form/_label.tsx
@@ -9,7 +9,10 @@ import type { FieldValues } from 'react-hook-form';
  * ラベル
  * ----------------------------------------------- */
 
-const Label = <TFieldValues extends FieldValues>({ label, rules }: TypeLabel<TFieldValues>) => {
+const Label = <TFieldValues extends FieldValues>({
+  label,
+  rules,
+}: TypeLabel<TFieldValues>): React.JSX.Element | null => {
   const isLabel = Boolean(label);
   if (!isLabel) {
     return null;

--- a/app/components/form/_radioBox.tsx
+++ b/app/components/form/_radioBox.tsx
@@ -42,7 +42,7 @@ const RadioBox = <TFieldValues extends FieldValues>({
   /*
    * 適用スタイル
    */
-  const getOptionLabelStyle = (disabled: boolean) => {
+  const getOptionLabelStyle = (disabled: boolean): object | null => {
     if (!disabled) {
       return null;
     }

--- a/app/components/form/_radioBoxCustom.tsx
+++ b/app/components/form/_radioBoxCustom.tsx
@@ -60,7 +60,7 @@ const OptionRow: React.FC<TypeBoxCustomOption> = ({
     };
   });
 
-  const getOptionLabelStyle = (disabled: boolean) => {
+  const getOptionLabelStyle = (disabled: boolean): object | null => {
     if (!disabled) {
       return null;
     }

--- a/app/components/layouts/layout/_loading.tsx
+++ b/app/components/layouts/layout/_loading.tsx
@@ -10,7 +10,7 @@ import type React from 'react';
  * ローディングコンポーネント
  * ----------------------------------------------- */
 
-const Loading: React.FC = () => {
+const Loading: React.FC = (): React.JSX.Element | null => {
   /*
    * ローディングフラグ取得 & 表示・非表示制御
    */

--- a/app/components/toast/_toast.tsx
+++ b/app/components/toast/_toast.tsx
@@ -23,7 +23,7 @@ import type {
 /*
  * メッセージ箇所
  */
-const ToastMessage = ({ message }: Pick<TypeToast, 'message'>) => {
+const ToastMessage = ({ message }: Pick<TypeToast, 'message'>): React.JSX.Element | null => {
   const isMessage = Boolean(message);
   if (!isMessage) {
     return null;
@@ -45,10 +45,10 @@ const offsetOption = {
 
 const useToastController = ({
   visible,
-  duration = 2000,
+  duration,
   onHide,
   onShow,
-  position = 'top',
+  position,
 }: Pick<TypeToast, 'visible' | 'duration' | 'onHide' | 'onShow' | 'position'>) => {
   const opacity = useSharedValue(0);
   const [mounted, setMounted] = React.useState(visible);

--- a/app/features/main/home/homeNest/child00/_component.tsx
+++ b/app/features/main/home/homeNest/child00/_component.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { color } from '../../../../../lib/mixin';
 
 import type { TypeResultArea } from './_type';
+import type React from 'react';
 
 /* -----------------------------------------------
  * 画面固有のコンポーネント
@@ -11,7 +12,7 @@ import type { TypeResultArea } from './_type';
 /*
  * 出力結果エリア
  */
-export const ResultArea: React.FC<TypeResultArea> = (formValues) => {
+export const ResultArea: React.FC<TypeResultArea> = (formValues): React.JSX.Element | null => {
   // formValues が空なら離脱
   const hasValues = Object.keys(formValues).length > 0;
   if (!hasValues) {

--- a/app/features/others/auth/_component.tsx
+++ b/app/features/others/auth/_component.tsx
@@ -32,7 +32,7 @@ export const SignInForm: React.FC<TypeAuthForm<TypeSignInValues>> = ({
   form,
   onSubmit,
   visible,
-}) => {
+}): React.JSX.Element | null => {
   if (!visible) {
     return null;
   }
@@ -83,7 +83,7 @@ export const SignUpForm: React.FC<TypeAuthForm<TypeSignUpValues>> = ({
   form,
   onSubmit,
   visible,
-}) => {
+}): React.JSX.Element | null => {
   if (!visible) {
     return null;
   }
@@ -134,7 +134,7 @@ export const VerifyForm: React.FC<TypeAuthForm<TypeVerifyValues>> = ({
   form,
   onSubmit,
   visible,
-}) => {
+}): React.JSX.Element | null => {
   if (!visible) {
     return null;
   }

--- a/stories/components/svg/Icon.stories.tsx
+++ b/stories/components/svg/Icon.stories.tsx
@@ -7,7 +7,7 @@ import { color } from '../../../app/lib/mixin';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import type React from 'react';
 
-const iconEntries = Object.entries(Icons).sort(([a], [b]) => a.localeCompare(b));
+const iconEntries = Object.entries(Icons).sort(([a = ''], [b = '']) => a.localeCompare(b));
 
 const iconUsageSnippet = `import { ${iconEntries.map(([name]) => name).join(', ')} } from '../../../app/components/svg/icon';
 

--- a/stories/components/svg/Logo.stories.tsx
+++ b/stories/components/svg/Logo.stories.tsx
@@ -7,7 +7,7 @@ import { color } from '../../../app/lib/mixin';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import type React from 'react';
 
-const logoEntries = Object.entries(Logos).sort(([a], [b]) => a.localeCompare(b));
+const logoEntries = Object.entries(Logos).sort(([a = ''], [b = '']) => a.localeCompare(b));
 
 const logoUsageSnippet = `import { ${logoEntries.map(([name]) => name).join(', ')} } from '../../../app/components/svg/logo';
 

--- a/stories/components/toast/Toast.stories.tsx
+++ b/stories/components/toast/Toast.stories.tsx
@@ -9,8 +9,7 @@ import type { TypeToastOptions } from '../../../app/lib/types/typeComponents';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 const escapeSingleQuotes = (text: string): string => {
-  const isText = Boolean(text);
-  if (!isText) {
+  if (text.length === 0) {
     return '';
   }
 
@@ -42,10 +41,8 @@ const formatToastOptions = (args: Partial<TypeToastOptions> | undefined): string
     `variant: '${normalizedVariant}'`,
   ];
 
-  const isNormalizedDuration = Boolean(normalizedDuration);
-
-  if (isNormalizedDuration) {
-    options.push(`duration: ${normalizedDuration ?? ''}`);
+  if (normalizedDuration !== null) {
+    options.push(`duration: ${normalizedDuration}`);
   }
 
   return options.join(', ');

--- a/stories/lib/mixin/styles/color.stories.tsx
+++ b/stories/lib/mixin/styles/color.stories.tsx
@@ -9,7 +9,7 @@ import type React from 'react';
 const colorEntries = Object.entries(color);
 
 const colorUsageSnippet = `import { color } from '../../../app/lib/mixin';\n\n${colorEntries
-  .map(([name, value]) => `color.${name}; // ${String(value)}`)
+  .map(([name, value]) => `color.${name}; // ${value}`)
   .join('\n')}`;
 
 const ColorCatalog: React.FC = () => (
@@ -18,7 +18,7 @@ const ColorCatalog: React.FC = () => (
       <View key={name} style={catalogStyles.item}>
         <View style={[catalogStyles.swatch, { backgroundColor: value }]} />
         <Text style={catalogStyles.name}>{name}</Text>
-        <Text style={catalogStyles.value}>{String(value)}</Text>
+        <Text style={catalogStyles.value}>{value}</Text>
       </View>
     ))}
   </View>


### PR DESCRIPTION
### Motivation
- Resolve multiple lint and TypeScript issues flagged by `sonarjs` and `@typescript-eslint` (mixed return types, null-dereference risks, unsafe `any`/argument-type mismatches) across UI components and story files.
- Ensure conditional-rendering components have stable return types to satisfy `sonarjs/function-return-type` and improve type safety for form option handling.
- Remove unnecessary conversions/assertions and harden reanimated mock helpers to avoid runtime null/undefined dereferences and linter complaints.

### Description
- Added explicit `React.JSX.Element | null` return types to conditional components (dialog parts, form helpers, toast message, auth forms, loading, ResultArea) to enforce consistent return shapes.
- Normalized checkbox/radio option handling by converting `option.value` to `String(...)` and updating toggle/getSelected helpers to return `string[]`, fixing `sonarjs/argument-type` and ensuring reliable `includes`/toggle behavior.
- Fixed reanimated mock utilities: made `hexToRgb`/`rgbToHex` safer, removed an unnecessary `as` assertion in `useSharedValue`, and rebuilt `withTiming` return value to satisfy return-type and null-dereference rules.
- Adjusted Storybook helpers: added default values in `sort` comparators, removed unnecessary `String(...)` conversions in color stories, and simplified toast story normalization logic to avoid unnecessary conversions and null issues.
- Minor type/signature improvements for style helper functions (e.g. `getOptionLabelStyle`, `getSelectedStyle`, `getToggleValue`) to satisfy ESLint/TypeScript rules across 16 modified files.

### Testing
- Ran `npx eslint . --max-warnings=0` and it passed successfully in this environment.
- Ran `npx tsc --noEmit` and type-checking passed with no errors.
- Note: running `yarn lint` could not be completed here due to a package manager/lockfile mismatch and blocked Yarn classic download (environment-level `empty-service@workspace` and corepack network/proxy errors), so equivalent `npx` lint/typecheck commands were used and validated instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a163b561dc88324be4aab11053061e0)