### PR TITLE
Add function API for Dialog (showDialog/hideDialog) and DialogProvider

### DIFF
--- a/app/components/dialog/_dialog.tsx
+++ b/app/components/dialog/_dialog.tsx
@@ -109,6 +109,7 @@ const DialogBottom = ({
 const Dialog = ({
   visible,
   title,
+  zIndex,
   notBackGroundPress = false,
   eventText,
   closeText,
@@ -138,7 +139,7 @@ const Dialog = ({
 
   return (
     <Modal animationType='none' onRequestClose={onClose} transparent visible={visible}>
-      <Animated.View style={[styles.container, animatedStyle]}>
+      <Animated.View style={[styles.container, { zIndex }, animatedStyle]}>
         {/*
          * 透過背景
          */}

--- a/app/components/dialog/_useDialog.ts
+++ b/app/components/dialog/_useDialog.ts
@@ -1,11 +1,29 @@
+import type { TypeDialogOptions, TypeDialogSubscribe } from '../../lib/types/typeComponents';
+
 /* -----------------------------------------------
  * Dialogを使用する際の関数
  * ----------------------------------------------- */
 
+const subscribers = new Set<(options: TypeDialogSubscribe) => void>();
+
 // Dialogプロバイダー用
+export const subscribeDialog = (subscriber: (options: TypeDialogSubscribe) => void) => {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+};
 
 // Dialogを表示する関数
-export const showDialog = () => {};
+export const showDialog = (options: TypeDialogOptions) => {
+  subscribers.forEach((subscriber) => {
+    subscriber({ ...options, visible: true });
+  });
+};
 
 // Dialogを非表示にする関数
-export const hideDialog = () => {};
+export const hideDialog = (dialogId?: string) => {
+  subscribers.forEach((subscriber) => {
+    subscriber({ dialogId, visible: false });
+  });
+};

--- a/app/components/dialog/index.ts
+++ b/app/components/dialog/index.ts
@@ -1,1 +1,2 @@
 export { default as Dialog } from './_dialog';
+export * from './_useDialog';

--- a/app/features/main/about/aboutNest/child00/_screen.tsx
+++ b/app/features/main/about/aboutNest/child00/_screen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert, StyleSheet, Text } from 'react-native';
 
 import { Button } from '../../../../../components/button';
-import { Dialog } from '../../../../../components/dialog';
+import { Dialog, showDialog } from '../../../../../components/dialog';
 import { Layout } from '../../../../../components/layouts/layout';
 
 import type { TypeDialogPattern } from './_type';
@@ -23,15 +23,30 @@ const Child00Screen: React.FC = () => {
     onClose();
   }, [onClose]);
 
+  /*
+   * showDialog関数 ボタン処理
+   */
+  const onShowDialog = () => {
+    // コンポーネントではなく showDialog関数を用いてダイアログを表示する場合
+    showDialog({
+      title: 'showDialog関数で ダイアログを開く',
+      eventText: 'イベントボタン',
+      closeText: '閉じるボタン',
+      onEvent: () => {
+        Alert.alert('Thanks to Tap', 'EventButton Tapped!!');
+      },
+      children: <Text>showDialog関数を用いて開いたダイアログです。</Text>,
+    });
+  };
+
   return (
     <Layout>
       <Text style={styles.title}>Dialog Example</Text>
 
       {/* ----------------------------------------
-       * Dialog ボタン
+       * Basic ダイアログ
        * ----------------------------------------- */}
-
-      {/* Basic ボタン */}
+      {/* ボタン */}
       <Button
         containerStyle={styles.buttonSpacing}
         onPress={() => {
@@ -40,40 +55,7 @@ const Child00Screen: React.FC = () => {
         title='Basic ダイアログを開く'
       />
 
-      {/* Not BackGroundPress ボタン */}
-      <Button
-        containerStyle={styles.buttonSpacing}
-        onPress={() => {
-          setVisibleDialog('notBackGroundPress');
-        }}
-        title='Not BackGroundPress ダイアログを開く'
-      />
-
-      {/* Long Contents ボタン */}
-      <Button
-        containerStyle={styles.buttonSpacing}
-        onPress={() => {
-          setVisibleDialog('longContent');
-        }}
-        title='Long Contents ダイアログを開く'
-      />
-
-      {/* Long Contents Only ボタン */}
-      <Button
-        onPress={() => {
-          setVisibleDialog('longContentsOnly');
-        }}
-        title='Long Contents Only ダイアログを開く'
-      />
-
-      {/* useDialog関数 ボタン */}
-      <Button onPress={() => {}} title='useDialogを用いて ダイアログを開く' />
-
-      {/* ----------------------------------------
-       * Dialog
-       * ----------------------------------------- */}
-
-      {/* Basic ダイアログ */}
+      {/* ダイアログ */}
       <Dialog
         closeText='閉じるボタン'
         eventText='イベントボタン'
@@ -90,7 +72,19 @@ const Child00Screen: React.FC = () => {
         </Text>
       </Dialog>
 
-      {/* Not BackGroundPress ダイアログ */}
+      {/* ----------------------------------------
+       * Not BackGroundPress ダイアログ
+       * ----------------------------------------- */}
+      {/* ボタン */}
+      <Button
+        containerStyle={styles.buttonSpacing}
+        onPress={() => {
+          setVisibleDialog('notBackGroundPress');
+        }}
+        title='Not BackGroundPress ダイアログを開く'
+      />
+
+      {/* ダイアログ */}
       <Dialog
         closeText='閉じるボタン'
         eventText='イベントボタン'
@@ -107,7 +101,19 @@ const Child00Screen: React.FC = () => {
         </Text>
       </Dialog>
 
-      {/* Long Contents ダイアログ */}
+      {/* ----------------------------------------
+       * Long Contents ダイアログ
+       * ----------------------------------------- */}
+      {/* ボタン */}
+      <Button
+        containerStyle={styles.buttonSpacing}
+        onPress={() => {
+          setVisibleDialog('longContent');
+        }}
+        title='Long Contents ダイアログを開く'
+      />
+
+      {/* ダイアログ */}
       <Dialog
         closeText='閉じるボタン'
         eventText='イベントボタン'
@@ -136,7 +142,19 @@ const Child00Screen: React.FC = () => {
         </Text>
       </Dialog>
 
-      {/* Long Contents Only ダイアログ */}
+      {/* ----------------------------------------
+       * Long Contents Only ダイアログ
+       * ----------------------------------------- */}
+      {/* ボタン */}
+      <Button
+        containerStyle={styles.buttonSpacing}
+        onPress={() => {
+          setVisibleDialog('longContentsOnly');
+        }}
+        title='Long Contents Only ダイアログを開く'
+      />
+
+      {/* ダイアログ */}
       <Dialog onClose={onClose} visible={visibleDialog === 'longContentsOnly'}>
         <Text>
           ・Long Contents Only ダイアログ{'\n'}
@@ -159,6 +177,11 @@ const Child00Screen: React.FC = () => {
           ))}
         </Text>
       </Dialog>
+
+      {/* ----------------------------------------
+       * showDialog関数 ダイアログ
+       * ----------------------------------------- */}
+      <Button onPress={onShowDialog} title='showDialog関数で ダイアログを開く' />
     </Layout>
   );
 };

--- a/app/lib/types/typeComponents/_dialog.ts
+++ b/app/lib/types/typeComponents/_dialog.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 export type TypeDialog = {
   visible: boolean;
+  zIndex?: number;
   title?: string;
   eventText?: string | React.ReactNode;
   closeText?: string | React.ReactNode;
@@ -10,3 +11,14 @@ export type TypeDialog = {
   onClose?: () => void;
   children?: ReactNode;
 };
+
+export type TypeDialogOptions = Omit<TypeDialog, 'visible'> & {
+  dialogId?: string;
+};
+
+export type TypeDialogState = TypeDialogOptions & {
+  dialogId: string;
+  visible: boolean;
+};
+
+export type TypeDialogSubscribe = TypeDialogOptions & { visible: boolean };

--- a/app/services/providerService/_appRootProvider.tsx
+++ b/app/services/providerService/_appRootProvider.tsx
@@ -3,6 +3,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import AuthProvider from './_authProvider';
+import DialogProvider from './_dialogProvider';
 import StoreProvider from './_storeProvider';
 import ToastProvider from './_toastProvider';
 
@@ -17,7 +18,9 @@ const AppRootProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
     <SafeAreaProvider>
       <AuthProvider>
         <StoreProvider>
-          <ToastProvider>{children}</ToastProvider>
+          <ToastProvider>
+            <DialogProvider>{children}</DialogProvider>
+          </ToastProvider>
         </StoreProvider>
       </AuthProvider>
     </SafeAreaProvider>

--- a/app/services/providerService/_dialogProvider.tsx
+++ b/app/services/providerService/_dialogProvider.tsx
@@ -1,7 +1,103 @@
+import React from 'react';
+
+import { Dialog, subscribeDialog } from '../../components/dialog';
+
+import type { TypeDialogState, TypeDialogSubscribe } from '../../lib/types/typeComponents';
+
 /* -----------------------------------------------
  * Dialog用 プロバイダー
  * ----------------------------------------------- */
 
-const DialogProvider = () => {};
+const DialogProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [dialogStates, setDialogStates] = React.useState<TypeDialogState[]>([]);
+  const dialogIdRef = React.useRef(0);
+
+  const createDialogId = React.useCallback((dialogId?: string) => {
+    if (dialogId !== undefined && dialogId !== '') {
+      return dialogId;
+    }
+
+    dialogIdRef.current += 1;
+    return `dialog-${String(dialogIdRef.current)}`;
+  }, []);
+
+  const addDialog = React.useCallback(
+    (options: TypeDialogSubscribe) => {
+      const nextDialog: TypeDialogState = {
+        dialogId: createDialogId(options.dialogId),
+        visible: true,
+        zIndex: options.zIndex,
+        title: options.title,
+        eventText: options.eventText,
+        closeText: options.closeText,
+        notBackGroundPress: options.notBackGroundPress,
+        onEvent: options.onEvent,
+        onClose: options.onClose,
+        children: options.children,
+      };
+
+      setDialogStates((prev) => [...prev, nextDialog]);
+    },
+    [createDialogId],
+  );
+
+  const hideDialogs = React.useCallback((dialogId?: string) => {
+    setDialogStates((prev) => {
+      if (dialogId === undefined || dialogId === '') {
+        return [];
+      }
+
+      return prev.filter((dialog) => dialog.dialogId !== dialogId);
+    });
+  }, []);
+
+  const handleDialogSubscription = React.useCallback(
+    (options: TypeDialogSubscribe) => {
+      if (options.visible) {
+        addDialog(options);
+        return;
+      }
+
+      hideDialogs(options.dialogId);
+    },
+    [addDialog, hideDialogs],
+  );
+
+  const handleCloseDialog = React.useCallback(
+    (dialogState: TypeDialogState) => {
+      dialogState.onClose?.();
+      hideDialogs(dialogState.dialogId);
+    },
+    [hideDialogs],
+  );
+
+  const handleEventDialog = React.useCallback((dialogState: TypeDialogState) => {
+    dialogState.onEvent?.();
+  }, []);
+
+  React.useEffect(() => {
+    const unsubscribe = subscribeDialog(handleDialogSubscription);
+
+    return unsubscribe;
+  }, [handleDialogSubscription]);
+
+  return (
+    <>
+      {children}
+      {dialogStates.map((dialogState) => (
+        <Dialog
+          key={dialogState.dialogId}
+          {...dialogState}
+          onClose={() => {
+            handleCloseDialog(dialogState);
+          }}
+          onEvent={() => {
+            handleEventDialog(dialogState);
+          }}
+        />
+      ))}
+    </>
+  );
+};
 
 export default DialogProvider;

--- a/app/services/providerService/index.ts
+++ b/app/services/providerService/index.ts
@@ -6,3 +6,4 @@
 export { default as AppRootProvider } from './_appRootProvider';
 export { default as AuthProvider, AuthContext } from './_authProvider';
 export { default as ToastProvider } from './_toastProvider';
+export { default as DialogProvider } from './_dialogProvider';

--- a/stories/components/dialog/Dialog.stories.tsx
+++ b/stories/components/dialog/Dialog.stories.tsx
@@ -41,6 +41,9 @@ const meta = {
     onClose: {
       description: 'クローズボタン処理 （および背景タップ時の処理）',
     },
+    zIndex: {
+      description: 'ダイアログのzIndex',
+    },
   },
 } satisfies Meta<typeof DialogComponent>;
 


### PR DESCRIPTION
### Motivation
- Enable using `Dialog` via function calls (like the existing toast API) so callers can show/hide dialogs without managing component state.
- Finish implementing the previously added placeholder for function-based Dialog usage.

### Description
- Implement `showDialog`, `hideDialog`, and `subscribeDialog` in `app/components/dialog/_useDialog.ts` to provide a publish/subscribe API for dialogs.
- Add `DialogProvider` in `app/services/providerService/_dialogProvider.tsx` to manage multiple dialog instances, auto-generate `dialogId`s, and support per-dialog hide via `dialogId` while invoking `onClose`/`onEvent` callbacks.
- Extend dialog types in `app/lib/types/typeComponents/_dialog.ts` with `TypeDialogOptions`, `TypeDialogState`, `TypeDialogSubscribe`, and `zIndex` to support function usage and ordering.
- Export the function API from `app/components/dialog/index.ts` and register `DialogProvider` in `AppRootProvider` (`app/services/providerService/_appRootProvider.tsx`), and apply `zIndex` support in the Dialog component (`app/components/dialog/_dialog.tsx`).

### Testing
- Ran `yarn lint` and resolved reported issues; lint finished successfully.
- Ran `git diff --check` for the affected files and there were no whitespace/format errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a369a8334e083248fc8ac39492afadc)